### PR TITLE
[bug] Fix defaults & k8s documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ jobs:
   include:
     - stage: tests
       script:
-      - export hosts="127.0.0.1 dashboard.openwisp.org controller.openwisp.org \
+      - export hosts="127.0.0.1 dashboard.openwisp.org controller.openwisp.org
                                 radius.openwisp.org topology.openwisp.org"
       - sudo bash -c 'echo "${hosts}" >> /etc/hosts'
+      - make compose-build
       - make develop-runtests

--- a/build/openwisp_base/Dockerfile
+++ b/build/openwisp_base/Dockerfile
@@ -20,23 +20,23 @@ RUN apt update && \
 
 ENV PYTHONPATH=/install/lib/python3.7/site-packages
 # Python Packages
-ARG OPENWISP_CONTROLLER_SOURCE=openwisp-controller~=0.4
+ARG OPENWISP_CONTROLLER_SOURCE=openwisp-controller~=0.4.0
 RUN pip install --upgrade --prefix='/install' ${OPENWISP_CONTROLLER_SOURCE}
-ARG OPENWISP_TOPOLOGY_SOURCE=openwisp-network-topology~=0.2
+ARG OPENWISP_TOPOLOGY_SOURCE=openwisp-network-topology~=0.2.0
 RUN pip install --upgrade --prefix='/install' ${OPENWISP_TOPOLOGY_SOURCE}
 ARG DJANGO_FREERADIUS_SOURCE=https://github.com/openwisp/django-freeradius/tarball/79f96a13e65bc95b81d41e643d4f8280bf357caa
 RUN pip install --upgrade --prefix='/install' ${DJANGO_FREERADIUS_SOURCE}
 ARG OPENWISP_RADIUS_SOURCE=https://github.com/openwisp/openwisp-radius/tarball/7150e28ffa985120accac1f47afbae9263c8c140
 RUN pip install --upgrade --prefix='/install' ${OPENWISP_RADIUS_SOURCE}
-ARG OPENWISP_USERS_SOURCE=openwisp-users~=0.1
+ARG OPENWISP_USERS_SOURCE=openwisp-users~=0.1.0
 RUN pip install --upgrade --prefix='/install' ${OPENWISP_USERS_SOURCE}
-ARG DJANGO_NETJSONCONFIG_SOURCE=django-netjsonconfig~=0.9
+ARG DJANGO_NETJSONCONFIG_SOURCE=django-netjsonconfig~=0.9.0
 RUN pip install --upgrade --prefix='/install' ${DJANGO_NETJSONCONFIG_SOURCE}
-ARG DJANGO_NETJSONGRAPH_SOURCE=django-netjsongraph~=0.5
+ARG DJANGO_NETJSONGRAPH_SOURCE=django-netjsongraph~=0.5.0
 RUN pip install --upgrade --prefix='/install' ${DJANGO_NETJSONGRAPH_SOURCE}
-ARG DJANGO_X509_SOURCE=django-x509~=0.5
+ARG DJANGO_X509_SOURCE=django-x509~=0.5.0
 RUN pip install --upgrade --prefix='/install' ${DJANGO_X509_SOURCE}
-ARG OPENWISP_UTILS_SOURCE=openwisp-utils~=0.4
+ARG OPENWISP_UTILS_SOURCE=openwisp-utils~=0.4.0
 RUN pip install --upgrade --prefix='/install' ${OPENWISP_UTILS_SOURCE}
 RUN pip install asgi_redis service_identity django-redis psycopg2 uwsgi sentry-sdk \
                 supervisor celery django-celery-beat \

--- a/docs/kubernetes/KUBERNETES.md
+++ b/docs/kubernetes/KUBERNETES.md
@@ -5,10 +5,12 @@
 
 1. Configure your domain with following A records, point your static IP to:
 
-  - dashboard.<your.domain>
-  - controller.<your.domain>
-  - radius.<your.domain>
-  - topology.<your.domain>
+```
+  dashboard.<your.domain>    --Public-IP--
+  controller.<your.domain>   --Public-IP--
+  radius.<your.domain>       --Public-IP--
+  topology.<your.domain>     --Public-IP--
+```
 
 2. (Optional) Postfix mail relay server (Example: Mailjet, Pepipost, Sendgrid, Mandrill)
 
@@ -23,7 +25,6 @@ kubectl apply -f ConfigMap.yml
 kubectl apply -f Storage.yml
 kubectl apply -f Service.yml
 kubectl apply -f Deployment.yml
-kubectl apply -f CertManager.yml
 ```
 
 5. Each Loadbalancer creates/assigns an IP address, add it to your DNS:

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -151,7 +151,7 @@ function init_tests {
     test_dashboard_login
     test_websocket
     test_freeradius
-    if [[ $FAILURE = 1 ]] && [[ $1 = logs ]]; then
+    if [[ $FAILURE = 1 ]] && [[ $TRAVIS ]]; then
         print_services_logs
     fi
     rm $COOKIES $PRE_LOGS


### PR DESCRIPTION
I learn something new today, `pip install --upgrade ABC~=0.9` translate to `0.X`
While, `pip install --upgrade ABC~=0.9.0` translate to `0.9.X`, it's the last dot that is variable, while I though pip only upgrades the minor version. :smile: