### PR TITLE
[change] Improved build of openwisp_base python deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,17 @@ You can build with your own python package by creating a file named `.build.env`
 - `OPENWISP_NOTIFICATION_SOURCE`
 - `OPENWISP_TOPOLOGY_SOURCE`
 - `OPENWISP_RADIUS_SOURCE`
+- `OPENWISP_IPAM_SOURCE`
 - `OPENWISP_USERS_SOURCE`
 - `OPENWISP_UTILS_SOURCE`
-- `OPENWISP_IPAM_SOURCE`
-- `DJANGO_SOURCE`
-- `DJANGO_NETJSONCONFIG_SOURCE`
 - `DJANGO_X509_SOURCE`
+- `DJANGO_SOURCE`
 
 For example, if you want to supply your own django and openwisp-controller source, your `.build.env` should be written like this:
 
 ```
 DJANGO_SOURCE=django==3.2
-OPENWISP_CONTROLLER_SOURCE=https://github.com/<username>/openwisp-api/tarball/master
+OPENWISP_CONTROLLER_SOURCE=https://github.com/<username>/openwisp-controller/tarball/master
 ```
 
 ### Disabling Services

--- a/build/openwisp_base/Dockerfile
+++ b/build/openwisp_base/Dockerfile
@@ -16,37 +16,45 @@ RUN apt update && \
                                               python3-pip libxml2-dev libxslt1-dev zlib1g-dev g++
 
 ENV PYTHONPATH=/install/lib/python3.10/site-packages
-# Python Packages
-## TODO: We need to temporarily lock the version of pip to avoid using
-## the new version of the dependency resolver which is not compatible
-## with openwisp modules
-RUN pip install --upgrade pip==20.2.4
 ARG OPENWISP_MONITORING_SOURCE=https://github.com/openwisp/openwisp-monitoring/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_MONITORING_SOURCE}
+RUN pip install --prefix='/install' --upgrade ${OPENWISP_MONITORING_SOURCE}
 ARG OPENWISP_FIRMWARE_SOURCE=https://github.com/openwisp/openwisp-firmware-upgrader/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_FIRMWARE_SOURCE}
-ARG OPENWISP_CONTROLLER_SOURCE=https://github.com/openwisp/openwisp-controller/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_CONTROLLER_SOURCE}
-ARG OPENWISP_NOTIFICATION_SOURCE=https://github.com/openwisp/openwisp-notifications/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_NOTIFICATION_SOURCE}
+RUN pip install --prefix='/install' --upgrade ${OPENWISP_FIRMWARE_SOURCE}
 ARG OPENWISP_TOPOLOGY_SOURCE=https://github.com/openwisp/openwisp-network-topology/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_TOPOLOGY_SOURCE}
+RUN pip install --prefix='/install' --upgrade ${OPENWISP_TOPOLOGY_SOURCE}
 ARG OPENWISP_RADIUS_SOURCE=https://github.com/openwisp/openwisp-radius/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_RADIUS_SOURCE}
+RUN pip install --prefix='/install' --upgrade ${OPENWISP_RADIUS_SOURCE}
 ARG OPENWISP_IPAM_SOURCE=https://github.com/openwisp/openwisp-ipam/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_IPAM_SOURCE}
-ARG OPENWISP_USERS_SOURCE=https://github.com/openwisp/openwisp-users/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_USERS_SOURCE}
-ARG DJANGO_X509_SOURCE=https://github.com/openwisp/django-x509/tarball/docker-openwisp-usage
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${DJANGO_X509_SOURCE}
-ARG OPENWISP_UTILS_SOURCE=openwisp-utils~=1.0.0
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_UTILS_SOURCE}
-RUN pip install --prefix='/install' channels_redis service_identity django-redis psycopg2 \
-                                    uwsgi sentry-sdk supervisor celery django-celery-beat \
-                                    django-cors-headers django-rest-auth jinja2 \
-                                    django-pipeline~=2.0.0
+RUN pip install --prefix='/install' --upgrade ${OPENWISP_IPAM_SOURCE}
+
+# here we try to install custom versions of the modules only if the
+# supplied argument does not equal the default value, because
+# otherwise these modules will have already been installed above
+ARG OPENWISP_CONTROLLER_SOURCE=default
+RUN if [ "$OPENWISP_CONTROLLER_SOURCE" != "default" ] ; then \
+    pip install --prefix='/install' --upgrade ${OPENWISP_CONTROLLER_SOURCE}; \
+    fi
+ARG OPENWISP_NOTIFICATION_SOURCE=default
+RUN if [ "$OPENWISP_NOTIFICATION_SOURCE" != "default" ] ; then \
+    pip install --prefix='/install' --upgrade ${OPENWISP_NOTIFICATION_SOURCE}; \
+    fi
+ARG OPENWISP_USERS_SOURCE=default
+RUN if [ "$OPENWISP_USERS_SOURCE" != "default" ] ; then \
+    pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_USERS_SOURCE}; \
+    fi
+ARG OPENWISP_UTILS_SOURCE=default
+RUN if [ "$OPENWISP_UTILS_SOURCE" != "default" ] ; then \
+    pip install --prefix='/install' --upgrade --force-reinstall ${OPENWISP_UTILS_SOURCE}; \
+    fi
+ARG DJANGO_X509_SOURCE=default
+RUN if [ "$DJANGO_X509_SOURCE" != "default" ]; then \
+    pip install --prefix='/install' --upgrade --force-reinstall ${DJANGO_X509_SOURCE}; \
+    fi
+
+COPY ./openwisp_base/requirements.txt /tmp/openwisp-deploy-requirements.txt
+RUN pip install --prefix='/install' -r /tmp/openwisp-deploy-requirements.txt
 ARG DJANGO_SOURCE=django~=4.0.0
-RUN pip install --prefix='/install' --upgrade --force-reinstall ${DJANGO_SOURCE}
+RUN pip install --prefix='/install' --upgrade ${DJANGO_SOURCE}
 
 FROM SYSTEM
 

--- a/build/openwisp_base/requirements.txt
+++ b/build/openwisp_base/requirements.txt
@@ -1,0 +1,9 @@
+channels_redis
+service_identity
+django-redis
+psycopg2
+uwsgi
+sentry-sdk
+supervisor~=4.2  # allows 4.x and > 4.2
+django-cors-headers~=3.1  # allows 3.x and > 3.1
+django-pipeline~=2.0  # allows 2.x

--- a/build/openwisp_dashboard/module_settings.py
+++ b/build/openwisp_dashboard/module_settings.py
@@ -54,8 +54,8 @@ INSTALLED_APPS = [
     'django_filters',
     # registration
     'rest_framework.authtoken',
-    'rest_auth',
-    'rest_auth.registration',
+    'dj_rest_auth',
+    'dj_rest_auth.registration',
     # social login
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.google',

--- a/build/openwisp_radius/module_settings.py
+++ b/build/openwisp_radius/module_settings.py
@@ -16,8 +16,8 @@ INSTALLED_APPS = [
     'django_filters',
     # registration
     'rest_framework.authtoken',
-    'rest_auth',
-    'rest_auth.registration',
+    'dj_rest_auth',
+    'dj_rest_auth.registration',
     # social login
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.google',


### PR DESCRIPTION
The build is taking an excessively long time to be executed, it looks to me that a lot of unnecessary actions are being performed so I spent some time cleaning up things that do not look ok to me.

- Removed obsolete django-rest-auth (we use a maintained fork called [dj_rest_auth](https://github.com/iMerica/dj-rest-auth) defined in OpenWISP RADIUS, so there's no need to redefine it here)
- Define additional requirements in requirements.txt, this will also allow us to monitor dependencies more easily
- Do not attempt installing custom openwisp modules unless a non default argument is supplied: there's no need to install again openwisp-users, openwisp-utils, django-x509 and even openwisp-controller unless a non default argument is supplied, because these modules are installed automatically in the previous pip install commands
- Avoid reinstalling every time to save build time - this was causing all the dependencies to be uninstalled and reinstalled each time, surely a waste of energy and time
- No need to use pip==20.2.4 anymore