### PR TITLE
[fix] Domains with multiple `.` in root domain

### DIFF
--- a/build/common/openwisp/settings.py
+++ b/build/common/openwisp/settings.py
@@ -28,7 +28,7 @@ for config in os.environ:
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 DEBUG = env_bool(os.environ['DEBUG_MODE'])
-ROOT_DOMAIN = f'.{".".join(os.environ["DASHBOARD_DOMAIN"].split(".")[-2:])}'
+ROOT_DOMAIN = f'.{".".join(os.environ["DASHBOARD_DOMAIN"].split(".")[1:])}'
 MAX_REQUEST_SIZE = int(os.environ['NGINX_CLIENT_BODY_SIZE']) * 1024 * 1024
 INSTALLED_APPS = []
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -51,13 +51,13 @@ Additionally, you can search for the following:
 
 ### `DASHBOARD_DOMAIN`
 
-- **Explaination:** Domain on which you want to access OpenWISP dashboard.
+- **Explaination:** Domain on which you want to access OpenWISP dashboard. You cannot use multi-part sub-domain (eg. dashboard.wisp.openwisp.org).
 - **Valid Values:** Domain
 - **Default:** dashboard.example.com
 
 ### `API_DOMAIN`
 
-- **Explaination:** Domain on which you want to access OpenWISP controller & topology API.
+- **Explaination:** Domain on which you want to access OpenWISP controller & topology API. You cannot use multi-part sub-domain (eg. api.wisp.openwisp.org).
 - **Valid Values:** Domain
 - **Default:** api.example.com
 


### PR DESCRIPTION
Currently, only domains in pattern `X.Y.Z` work, with this changep
domains with `X.Y.Z.A` should work as well.
However, domains with multiple parts in subdomain might not work.

This is a fair trade because multi-part subdomain are not used while
multi-part root domain is frequent.