### PR TITLE
[dashboard] Added firmware-upgrader private storage URL

### DIFF
--- a/images/openwisp_api/urls.py
+++ b/images/openwisp_api/urls.py
@@ -18,12 +18,16 @@ if env_bool(os.environ['USE_OPENWISP_TOPOLOGY']):
     urlpatterns += [path('api/v1/', include(topology_api(views)))]
 
 if env_bool(os.environ['USE_OPENWISP_FIRMWARE']):
+    from openwisp_firmware_upgrader.private_storage.urls import (
+        urlpatterns as fw_private_storage_urls,
+    )
+
     urlpatterns += [
         path(
             'api/v1/',
             include('openwisp_firmware_upgrader.api.urls', namespace='firmware'),
         ),
-        path('', include('openwisp_firmware_upgrader.private_storage.urls')),
+        path('', include((fw_private_storage_urls, 'firmware'), namespace='firmware')),
     ]
 
 if env_bool(os.environ['USE_OPENWISP_MONITORING']):

--- a/images/openwisp_dashboard/urls.py
+++ b/images/openwisp_dashboard/urls.py
@@ -23,5 +23,20 @@ if env_bool(os.environ['USE_OPENWISP_TOPOLOGY']):
 
     urlpatterns += [path('topology/', include(visualizer_urls))]
 
+if env_bool(os.environ['USE_OPENWISP_FIRMWARE']):
+    # When using S3_REVERSE_PROXY feature of django-private-storage,
+    # the storage backend reverse the "serve_private_file" URL
+    # pattern in order to proxy the file with the correct URL.
+    from openwisp_firmware_upgrader.private_storage.urls import (
+        urlpatterns as fw_private_storage_urls,
+    )
+
+    urlpatterns += [
+        path(
+            '',
+            include((fw_private_storage_urls, 'firmware'), namespace='firmware'),
+        )
+    ]
+
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
When using S3_REVERSE_PROXY feature of django-private-storage,
the storage backend reverses the "serve_private_file" URL
pattern in order to proxy the file with the correct URL.

Therefore, the dashboard container requires the
"serve_private_file" URL pattern.