### PR TITLE
[feature] Added utilities for startup/readiness/liveness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Setup on kubernetes is complex and requires prior knowledge about linux systems,
 - [Bare Metal](docs/kubernetes/BARE_METAL.md)
 - [Google Cloud](docs/kubernetes/GOOGLE_CLOUD.md)
 
+Useful commands for startup and readiness probes which are provided
+by the images:
+
+- startup probe example: `test $(ps aux | grep -c uwsgi) -ge 2`
+- readiness probe example: `python services.py uwsgi_status "127.0.0.1:8001"`
+
 ## Customization
 
 The following commands will create the directory structure required for

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -4,7 +4,6 @@ FROM python:3.10-slim-bullseye AS SYSTEM
 # 1. gettext: Required by envsubst used in scripts
 # 2. openwisp-radius/weasyprint: libcairo2 libpangocairo-1.0
 # 3. openwisp-monitoring: fping gdal-bin
-# 4. sudo
 RUN apt update && \
     apt install --yes --no-install-recommends \
     libcairo2 apt-utils libpangocairo-1.0-0 \
@@ -14,7 +13,7 @@ RUN apt update && \
 RUN apt update && \
     apt install --yes --no-install-recommends \
     gcc libpq-dev libjpeg-dev libffi-dev python3-dev \
-    python3-pip libxml2-dev libxslt1-dev zlib1g-dev g++
+    python3-pip libxml2-dev libxslt1-dev zlib1g-dev g++ procps
 
 RUN useradd --system --password '' --create-home --shell /bin/bash \
     --gid root --uid 1001 openwisp


### PR DESCRIPTION
This patch allows to easily set up startup and readiness probes in kubernetes with tools that are directly included in the base images. I also updated the kubernetes section of the docs to briefly mention these.