### PR TITLE
[fix] Fix alpine dependency issues

### DIFF
--- a/images/openwisp_nfs/Dockerfile
+++ b/images/openwisp_nfs/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
-RUN apk add --no-cache --update --verbose tzdata~=2022c-r0 nfs-utils~=2.5.4-r1 && \
+RUN apk add --no-cache --update --verbose \
+            tzdata~=2022f-r1 \
+            nfs-utils~=2.6.1-r1 && \
     rm -rf /var/cache/apk/* /tmp/*
 
 COPY ./openwisp_nfs/init_command.sh /init_command.sh

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,6 +1,9 @@
-FROM nginx:alpine
+FROM nginx:1.23.2-alpine
 
-RUN apk add --update --no-cache certbot~=1.27.0-r0 openssl=1.1.1q-r0 certbot-nginx~=1.27.0-r0 && \
+RUN apk add --update --no-cache \
+            openssl~=1.1.1s-r0 \
+            certbot~=1.27.0-r0 \
+            certbot-nginx~=1.27.0-r0 && \
     rm -rf /var/cache/apk/* /tmp/*
 
 WORKDIR /etc/nginx/

--- a/images/openwisp_openvpn/Dockerfile
+++ b/images/openwisp_openvpn/Dockerfile
@@ -1,7 +1,10 @@
 # hadolint ignore=DL3007
-FROM kylemanna/openvpn:latest
+FROM kylemanna/openvpn:2.4
 
-RUN apk add --no-cache tzdata~=2022a-r0 postgresql-client~=12.10-r0  supervisor~=4.2.0-r0 && \
+RUN apk add --no-cache \
+            tzdata~=2022a-r0 \
+            postgresql-client~=12.10-r0 \
+            supervisor~=4.2.0-r0 && \
     rm -rf /var/cache/apk/* /tmp/*
 CMD ["sh", "init_command.sh"]
 EXPOSE 1194

--- a/images/openwisp_postfix/Dockerfile
+++ b/images/openwisp_postfix/Dockerfile
@@ -1,8 +1,14 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 WORKDIR /opt/openwisp/
-RUN apk add --no-cache --upgrade openssl~=1.1.1o-r0 cyrus-sasl~=2.1.28-r0 cyrus-sasl-plain~=2.1.28-r0 cyrus-sasl-login~=2.1.28-r0 && \
-    apk add --no-cache postfix~=3.5.16-r0 rsyslog~=8.2004.0-r2 tzdata~=2022a-r0 && \
+RUN apk add --no-cache --upgrade \
+            openssl~=1.1.1s-r0 \
+            cyrus-sasl~=2.1.28-r1	\
+            cyrus-sasl-login~=2.1.28-r1 && \
+    apk add --no-cache \
+            postfix~=3.7.3-r0 \
+            rsyslog~=8.2204.1-r0	 \
+            tzdata~=2022f-r1 && \
     rm -rf /tmp/* /var/cache/apk/*
 
 CMD ["sh", "init_command.sh"]


### PR DESCRIPTION
Do not depend on "latest" tags because as new images
are released, the dependencies in our dockerfiles
will not work anymore and our build system will break.