### PR TITLE
[change] Remove docker hub publishing

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -24,25 +24,11 @@ jobs:
         run: |
           echo "127.0.0.1 dashboard.openwisp.org api.openwisp.org" | sudo tee -a /etc/hosts
 
-      # the following action is equivalent to
-      # echo "$DOCKER_HUB_SECRET" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_SECRET }}
-
-      - name: Build & Publish to Docker Hub
-        run: |
-          make publish TAG=edge USER=registry.docker.com/openwisp || (docker-compose logs && exit 1)
-        env:
-          SELENIUM_HEADLESS: 1
-
-      - name: Login to GitLab Container Registry
+      - name: Login to Gitlab Container Registry
         uses: docker/login-action@v1
         with:
           registry: registry.gitlab.com
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ secrets.GITLAB_DOCKER_REGISTRY_USER }}
           password: ${{ secrets.GITLAB_DOCKER_REGISTRY_TOKEN }}
 
       # Skip image builds and tests since they were done when

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ The sample files for deployment on kubernetes are available in the `deploy/examp
 
 \* Roughly the same features would be available but it's not an exact one-to-one mapping.
 
-The images are hosted on [Docker Hub](https://hub.docker.com/u/openwisp)
-and [GitLab Container Registry](https://gitlab.com/openwisp/docker-openwisp/container_registry).
+The images are hosted on [GitLab Container Registry](https://gitlab.com/openwisp/docker-openwisp/container_registry).
 
 ### Image Tags
 


### PR DESCRIPTION
Removes docker hub completely to avoid confusion.


I also felt like renaming the secret `DOCKER_USER` to `GITLAB_DOCKER_REGISTRY_USER` is appropriate. Somebody of you needs to to that, before merging.


See #272 