### PR TITLE
[chores] Updated tldextract and made ROOT_DOMAIN logic consistent

### DIFF
--- a/images/common/openwisp/settings.py
+++ b/images/common/openwisp/settings.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 
+import tldextract
 from openwisp.utils import (
     env_bool,
     is_string_env_bool,
@@ -28,8 +29,8 @@ for config in os.environ:
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 DEBUG = env_bool(os.environ['DEBUG_MODE'])
-ROOT_DOMAIN = f'.{".".join(os.environ["DASHBOARD_DOMAIN"].split(".")[1:])}'
 MAX_REQUEST_SIZE = int(os.environ['NGINX_CLIENT_BODY_SIZE']) * 1024 * 1024
+ROOT_DOMAIN = '.' + tldextract.extract(os.environ["DASHBOARD_DOMAIN"]).registered_domain
 INSTALLED_APPS = []
 
 if 'DJANGO_ALLOWED_HOSTS' not in os.environ:

--- a/images/openwisp_base/requirements.txt
+++ b/images/openwisp_base/requirements.txt
@@ -8,6 +8,7 @@ django-cors-headers~=3.1  # allows 3.x and > 3.1
 django-pipeline~=2.0  # allows 2.x
 uwsgi~=2.0.20
 django-celery-email~=3.0.0
+tldextract~=5.1.2
 # these add support for object storage
 # (eg: Amazon S3, GCS)
 django-storages~=1.12.3

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,7 +1,7 @@
-FROM nginx:1.23.3-alpine
+FROM nginx:1.23.4-alpine
 
 RUN apk add --update --no-cache \
-            openssl~=3.0.12-r5 \
+            openssl~=3.0.13-r0 \
             certbot~=1.32.0-r0 \
             certbot-nginx~=1.32.0-r0 && \
     rm -rf /var/cache/apk/* /tmp/*

--- a/images/openwisp_nginx/requirements.txt
+++ b/images/openwisp_nginx/requirements.txt
@@ -1,1 +1,1 @@
-tldextract~=3.2.0
+tldextract~=5.1.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-docker~=7.0.0
+docker @ git+https://github.com/docker/docker-py.git@7785ad913ddf2d86478f08278bb2c488d05a29ff#egg=docker
 openwisp-utils[qa,selenium] @ https://github.com/openwisp/openwisp-utils/tarball/master


### PR DESCRIPTION
A variable called ROOT_DOMAIN was computed with different methods in nginx and base image.
The approach using the tldextract library seems more robust, therefore I decided to update the library and change the base image settings code accordingly.

Closes #281 
Closes #273