### PR TITLE
[deps] Fixed openssl dependency in Nginx Image #318

### DIFF
--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:1.27.0-alpine
 
 RUN apk add --update --no-cache \
+            openssl~=3.1.7-r0 \
             py3-pip~=23.3.1-r0 \
             certbot~=2.7.4-r0 \
             certbot-nginx~=2.7.4-r0 && \


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

In #318, I initially removed the OpenSSL dependency from the Nginx image, assuming it was included in the base image. However, the base image removes the OpenSSL package in a later build step. This commit reinstates the OpenSSL dependency to ensure proper functionality.

Related to #318
