### PR TITLE
[fix] Fix create_default_topology condition check #421

### DIFF
--- a/images/openwisp_dashboard/load_init_data.py
+++ b/images/openwisp_dashboard/load_init_data.py
@@ -254,6 +254,6 @@ if __name__ == '__main__':
     create_default_credentials()
     create_ssh_key_template()
 
-    if os.environ.get('USE_OPENWISP_TOPOLOGY', False) == "True":
+    if env_bool(os.environ.get('USE_OPENWISP_TOPOLOGY')):
         Topology = load_model('topology', 'Topology')
         create_default_topology(default_vpn)

--- a/images/openwisp_dashboard/load_init_data.py
+++ b/images/openwisp_dashboard/load_init_data.py
@@ -14,11 +14,11 @@ import os
 
 import django
 import redis
+from openwisp.utils import env_bool
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp.settings')
 django.setup()
 from django.conf import settings  # noqa
-from openwisp.utils import env_bool
 
 
 def create_admin():

--- a/images/openwisp_dashboard/load_init_data.py
+++ b/images/openwisp_dashboard/load_init_data.py
@@ -254,6 +254,6 @@ if __name__ == '__main__':
     create_default_credentials()
     create_ssh_key_template()
 
-    if os.environ.get('USE_OPENWISP_TOPOLOGY', False):
+    if os.environ.get('USE_OPENWISP_TOPOLOGY', False) == "True":
         Topology = load_model('topology', 'Topology')
         create_default_topology(default_vpn)

--- a/images/openwisp_dashboard/load_init_data.py
+++ b/images/openwisp_dashboard/load_init_data.py
@@ -18,6 +18,7 @@ import redis
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'openwisp.settings')
 django.setup()
 from django.conf import settings  # noqa
+from openwisp.utils import env_bool
 
 
 def create_admin():


### PR DESCRIPTION
Fix if condition checking if the default topology should be created.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #421 

## Description of Changes

Currently the `if` condition returns `True` even if the variable `USE_OPENWISP_TOPOLOGY` is set to `False`.
This is due to the fact that the value returned is `"False"`, which evaluates to `True` in Python.

## Screenshot

n/a
