### PR TITLE
[feature] Add support for Ubuntu 24.04 in auto-install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: CI Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4

--- a/deploy/auto-install.sh
+++ b/deploy/auto-install.sh
@@ -247,8 +247,8 @@ init_setup() {
 		echo -e "  - 2GB RAM (Minimum)"
 		echo -e "  - Root privileges"
 		echo -e "  - Supported systems"
-		echo -e "    - Debian: 10 & 11"
-		echo -e "    - Ubuntu 18.04, 18.10, 20.04 & 22.04"
+		echo -e "    - Debian: 11 & 12"
+		echo -e "    - Ubuntu 22.04 & 24.04"
 		echo -e ${YLW}"\nYou can use -u\--upgrade if you are upgrading from an older version.\n"${NON}
 	fi
 
@@ -265,11 +265,11 @@ init_setup() {
 	apt -qq --yes install lsb-release &>>$LOG_FILE
 	system_id=$(lsb_release --id --short)
 	system_release=$(lsb_release --release --short)
-	incompatible_message="$system_id $system_release is not support. Installation might fail, continue anyway? (Y/n): "
+	incompatible_message="$system_id $system_release is not supported. Installation might fail, continue anyway? (Y/n): "
 
 	if [[ "$system_id" == "Debian" || "$system_id" == "Ubuntu" ]]; then
 		case "$system_release" in
-		18.04 | 20.04 | 22.04 | 10 | 11 | 12)
+		22.04 | 24.04 | 11 | 12)
 			if [[ "$1" == "upgrade" ]]; then
 				report_ok && upgrade_debian
 			else
@@ -295,8 +295,8 @@ init_help() {
 	echo -e "  - 2GB RAM (Minimum)"
 	echo -e "  - Root privileges"
 	echo -e "  - Supported systems"
-	echo -e "    - Debian: 10 & 11"
-	echo -e "    - Ubuntu 18.04, 18.10, 20.04, 22.04\n"
+	echo -e "    - Debian: 11 & 12"
+	echo -e "    - Ubuntu 22.04 & 24.04\n"
 	echo -e "  -i\--install : (default) Install OpenWISP"
 	echo -e "  -u\--upgrade : Change OpenWISP version already setup with this script"
 	echo -e "  -h\--help    : See this help message"

--- a/images/openwisp_freeradius/Dockerfile
+++ b/images/openwisp_freeradius/Dockerfile
@@ -2,7 +2,7 @@ FROM freeradius/freeradius-server:3.2.7-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update tzdata~=2024b-r1 \
-                                postgresql17-client~=17.4-r0 && \
+                                postgresql17-client~=17.5-r0 && \
     rm -rf /var/cache/apk/* /tmp/*
 
 RUN addgroup -S freerad && \


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description 

- Dropped support for the following OS in auto-install script:
  - Ubuntu 18.04
  - Ubuntu 20.04
  - Debian 10

