### PR TITLE
[fix] Updated Django urlpatterns in openwisp_websocket image #462

### DIFF
--- a/images/openwisp_websocket/urls.py
+++ b/images/openwisp_websocket/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
-    url(r"^admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
 ]


### PR DESCRIPTION




## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #462


## Description of Changes

The urlpattern in openwisp_websocket images was using django.conf.urls.url which have been deprecated in Django 3.0.

Updated the urlpattern to use django.urls.path

