### PR TITLE
Add support for non-default Nginx external ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,8 +131,8 @@ services:
          - dashboard.internal
          - api.internal
     ports:
-      - "80:80"
-      - "443:443"
+      - "${NGINX_80_PORT:-80}:80"
+      - "${NGINX_SSL_PORT:-443}:443"
     depends_on:
       - dashboard
       - api

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -869,6 +869,26 @@ Nginx
 - **Example:** ``index index.html index.htm;``.
 - **Default:** ``""`` (empty string).
 
+``NGINX_SSL_PORT``
+~~~~~~~~~~~~~~~~~~~~
+
+- **Explanation:** Nginx container external port. Useful to set if, for
+  example, OpenWISP is going to run behind a reverse proxy listening on
+  the default port on the same host. This variable is only applicable when
+  ``SSL_CERT_MODE`` is ``Yes`` or ``SelfSigned``.
+- **Valid Values:** ``INTEGER``.
+- **Default:** ``443``.
+
+``NGINX_80_PORT``
+~~~~~~~~~~~~~~~~~~~~
+
+- **Explanation:** Nginx container external port. Useful to set if, for
+  example, OpenWISP is going to run behind a reverse proxy listening on
+  the default port on the same host. This variable is only applicable when
+  ``SSL_CERT_MODE`` is ``False``.
+- **Valid Values:** ``INTEGER``.
+- **Default:** ``80``.
+
 ``NGINX_GZIP_SWITCH``
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #496.

Please [open a new issue](https://github.com/openwisp/docker-openwisp/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Let users set custom external HTTPS/HTTP ports for the `nginx` container, using new, documented `.env` variables `NGINX_SSL_PORT` and `NGINX_80_PORT`. The default ports are used if these variables are not specified. Useful if e.g. OpenWISP is running behind a reverse proxy on the same host (quite common for Docker applications). 

## Screenshot

Please include any relevant screenshots.
