### PR TITLE
[urls] Fix namespace conflicts in API container #241

### DIFF
--- a/images/openwisp_api/urls.py
+++ b/images/openwisp_api/urls.py
@@ -5,7 +5,7 @@ from django.urls import include, path
 from openwisp.utils import env_bool, openwisp_controller_urls
 from openwisp_users.api.urls import get_api_urls as users_api
 
-urlpatterns = openwisp_controller_urls() + [
+urlpatterns = openwisp_controller_urls("api") + [
     path("admin/", admin.site.urls),
     path("api/v1/", include((users_api(), "users"))),
     path("api/v1/", include("openwisp_utils.api.urls")),
@@ -26,7 +26,7 @@ if env_bool(os.environ["USE_OPENWISP_FIRMWARE"]):
         path("", include("openwisp_firmware_upgrader.urls")),
         path(
             "",
-            include((fw_private_storage_urls, "firmware"), namespace="firmware"),
+            include((fw_private_storage_urls, "firmware"), namespace="api-firmware"),
         ),
     ]
 


### PR DESCRIPTION
Both dashboard and API containers were using same namespaces causing Django warnings. Added prefix param to openwisp_controller_urls() and changed firmware namespace in API to avoid conflicts.

Fixes #241

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #241 .

Please [open a new issue](https://github.com/openwisp/docker-openwisp/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

  - Added prefix parameter to `openwisp_controller_urls()` function
  - Updated API container to use `api-firmware` namespace instead of `firmware`
  - Applied `api` prefix to controller URLs in API container to avoid IPAM conflicts
   ## Testing
  - Built API container successfully with no errors
  - Verified Python syntax and imports work correctly


## Screenshot

Please include any relevant screenshots.
<img width="758" height="442" alt="Screenshot 2025-10-04 at 12 09 27 AM" src="https://github.com/user-attachments/assets/e1c2851e-133b-45cf-a4d0-090e713eb538" />
<img width="937" height="425" alt="241" src="https://github.com/user-attachments/assets/b66882e2-4949-439b-a30e-587be247b29d" />
<img width="752" height="451" alt="Screenshot 2025-10-04 at 12 13 45 AM" src="https://github.com/user-attachments/assets/442af126-67a2-4eac-a79e-efcc5446305d" />
