### PR TITLE
[auto-install] Fix OpenVPN container starting when disabled #490

### DIFF
--- a/deploy/auto-install.sh
+++ b/deploy/auto-install.sh
@@ -149,7 +149,7 @@ setup_docker_openwisp() {
 		if [[ -z "$vpn_domain" ]]; then
 			set_env "VPN_DOMAIN" "openvpn.${domain}"
 		elif [[ "${vpn_domain,,}" == "n" ]]; then
-			set_env "VPN_DOMAIN" "example.com"
+			set_env "VPN_DOMAIN" ""
 		else
 			set_env "VPN_DOMAIN" "$vpn_domain"
 		fi


### PR DESCRIPTION
When user selects 'n' to disable OpenVPN during auto-install, the script was setting VPN_DOMAIN to "example.com" instead of an empty string. This caused the OpenVPN container to still start and fail on systems without /dev/net/tun device.



## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #490 

Please [open a new issue](https://github.com/openwisp/docker-openwisp/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

The existing logic in init_command.sh already handles this case by exiting when VPN_DOMAIN is empty. This change ensures the variable is properly set to empty when OpenVPN is disabled.

## Screenshot
<img width="477" height="148" alt="Screenshot 2025-10-05 at 9 04 38 AM" src="https://github.com/user-attachments/assets/ca88ace5-612e-40d4-8879-434f0077fa9b" />

Please include any relevant screenshots.
