### PR TITLE
[chores] Relax requirements.txt ranges to reduce dependabot PRs

### DIFF
--- a/images/openwisp_base/requirements.txt
+++ b/images/openwisp_base/requirements.txt
@@ -3,13 +3,13 @@ service_identity
 django-redis
 psycopg2
 sentry-sdk
-supervisor~=4.2  # allows 4.x and > 4.2
-django-cors-headers~=4.7
-django-pipeline~=4.0
-uwsgi~=2.0.30
+supervisor>=4.3.0,<4.4.0
+django-cors-headers>=4.9.0,<4.10.0
+django-pipeline>=4.1.0,<4.2.0
+uwsgi>=2.0.30,<2.1.0
 django-celery-email~=3.0.0
-tldextract~=5.3.0
+tldextract>=5.3.0,<5.4.0
 # these add support for object storage
 # (eg: Amazon S3, GCS)
-django-storages~=1.14.6
-boto3~=1.40.43
+django-storages>=1.14.6,<1.15.0
+boto3>=1.40.49,<1.41.0

--- a/images/openwisp_nginx/requirements.txt
+++ b/images/openwisp_nginx/requirements.txt
@@ -1,1 +1,1 @@
-tldextract~=5.3.0
+tldextract>=5.3.0,<5.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-docker~=7.1.0
+docker>=7.1.0,<7.2.0
 openwisp-utils[qa,selenium] @ https://github.com/openwisp/openwisp-utils/tarball/1.2


### PR DESCRIPTION
We don't need a dependabot PR each time a new boto version is out.