### PR TITLE
[deps] Stop pinning apk deps, but run dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,19 +4,19 @@ updates:
     directories:
       - "**/*"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "[deps] "
   - package-ecosystem: "docker"
     directories:
       - "**/*"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "[deps] "
-  - package-ecosystem: "github-actions" # Check for GitHub Actions updates
-    directory: "/" # The root directory where the Ansible role is located
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: "monthly" # Check for updates weekly
+      interval: "weekly"
     commit-message:
       prefix: "[ci] "

--- a/images/openwisp_freeradius/Dockerfile
+++ b/images/openwisp_freeradius/Dockerfile
@@ -1,8 +1,9 @@
 FROM freeradius/freeradius-server:3.2.7-alpine
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache --update tzdata~=2024b-r1 \
-                                postgresql17-client~=17.6-r0 && \
+RUN apk add --no-cache --update \
+            tzdata \
+            postgresql17-client && \
     rm -rf /var/cache/apk/* /tmp/*
 
 RUN addgroup -S freerad && \

--- a/images/openwisp_nfs/Dockerfile
+++ b/images/openwisp_nfs/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.22
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache --update --verbose \
-            tzdata~=2025b-r0 \
-            nfs-utils~=2.6.4-r4 && \
+            tzdata \
+            nfs-utils && \
     rm -rf /var/cache/apk/* /tmp/*
 
 COPY ./openwisp_nfs/init_command.sh /init_command.sh

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -2,9 +2,9 @@ FROM nginx:1.29.1-alpine
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache \
-            py3-pip~=25.1.1-r0 \
-            certbot~=4.0.0-r0 \
-            certbot-nginx~=4.0.0-r1 \
+            py3-pip \
+            certbot \
+            certbot-nginx \
             openssl && \
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/images/openwisp_openvpn/Dockerfile
+++ b/images/openwisp_openvpn/Dockerfile
@@ -1,10 +1,11 @@
 # hadolint ignore=DL3007
 FROM kylemanna/openvpn:2.4
 
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
-            curl~=7.79.1-r1 \
-            tzdata~=2022a-r0 \
-            supervisor~=4.2.0-r0 && \
+            curl \
+            tzdata \
+            supervisor && \
     rm -rf /var/cache/apk/* /tmp/*
 CMD ["sh", "init_command.sh"]
 EXPOSE 1194

--- a/images/openwisp_postfix/Dockerfile
+++ b/images/openwisp_postfix/Dockerfile
@@ -3,13 +3,12 @@ FROM alpine:3.22
 WORKDIR /opt/openwisp/
 # hadolint ignore=DL3018
 RUN apk add --no-cache --upgrade \
-            cyrus-sasl~=2.1.28-r8	\
-            cyrus-sasl-login~=2.1.28-r8 \
-            openssl && \
-    apk add --no-cache \
-            postfix~=3.10.4-r0 \
-            rsyslog~=8.2410.0-r1 \
-            tzdata~=2025b-r0 && \
+            cyrus-sasl	\
+            cyrus-sasl-login \
+            openssl \
+            postfix \
+            rsyslog \
+            tzdata && \
     rm -rf /tmp/* /var/cache/apk/*
 
 CMD ["sh", "init_command.sh"]


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Pinning our apk dependencies brought maintainance nightmares:

- PRs frequently breaking due to yanked packages
- Dependabot PRs not able to update base images due to versions being pinned and hence not available in new base images

This patch aims to get more frequent dependabot PRs but with less failures, which will allow us to merge them faster.