### PR TITLE
[fix] Updated auto-install script prompt for SSL certificate #556

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,6 @@ UWSGI_LISTEN=100
 # Additional
 SSL_CERT_MODE=SelfSigned
 TZ=UTC
-CERT_ADMIN_EMAIL=example@example.org
 DJANGO_LANGUAGE_CODE=en-gb
 DB_NAME=openwisp
 INFLUXDB_NAME=openwisp

--- a/deploy/auto-install.sh
+++ b/deploy/auto-install.sh
@@ -117,8 +117,8 @@ setup_docker_openwisp() {
 		echo -ne ${GRN}"(4/5) Site manager email: "${NON}
 		read django_default_email
 		# SSL Configuration
-		echo -ne ${GRN}"(5/5) Enter letsencrypt email (leave blank for self-signed certificate): "${NON}
-		read letsencrypt_email
+		echo -ne ${GRN}"(5/5) Use Let's Encrypt SSL? (y/N, blank for no): "${NON}
+		read use_letsencrypt
 	else
 		cp $env_path $ENV_USER &>>$LOG_FILE
 	fi
@@ -161,11 +161,11 @@ setup_docker_openwisp() {
 		python3 $INSTALL_PATH/build.py change-secret-key >/dev/null
 		python3 $INSTALL_PATH/build.py change-database-credentials >/dev/null
 		# SSL Configuration
-		set_env "CERT_ADMIN_EMAIL" "$letsencrypt_email"
-		if [[ -z "$letsencrypt_email" ]]; then
-			set_env "SSL_CERT_MODE" "SelfSigned"
-		else
+		use_letsencrypt_lower=$(echo "$use_letsencrypt" | tr '[:upper:]' '[:lower:]')
+		if [[ "$use_letsencrypt_lower" == "y" || "$use_letsencrypt_lower" == "yes" ]]; then
 			set_env "SSL_CERT_MODE" "Yes"
+		else
+			set_env "SSL_CERT_MODE" "SelfSigned"
 		fi
 		# Other
 		hostname=$(echo "$django_default_email" | cut -d @ -f 2)

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -72,14 +72,6 @@ properly on your system.
   <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>`__.
 - **Default:** ``UTC``.
 
-``CERT_ADMIN_EMAIL``
-~~~~~~~~~~~~~~~~~~~~
-
-- **Explanation:** Required by certbot. Email used for registration and
-  recovery contact.
-- **Valid Values:** A comma separated list of valid email addresses.
-- **Default:** ``example@example.com``.
-
 ``SSL_CERT_MODE``
 ~~~~~~~~~~~~~~~~~
 

--- a/images/common/utils.sh
+++ b/images/common/utils.sh
@@ -32,14 +32,12 @@ function create_prod_certs {
 	if [ ! -f /etc/letsencrypt/live/${DASHBOARD_DOMAIN}/privkey.pem ]; then
 		certbot certonly --standalone --noninteractive --agree-tos \
 			--rsa-key-size 4096 \
-			--domain ${DASHBOARD_DOMAIN} \
-			--email ${CERT_ADMIN_EMAIL}
+			--domain ${DASHBOARD_DOMAIN}
 	fi
 	if [ ! -f /etc/letsencrypt/live/${API_DOMAIN}/privkey.pem ]; then
 		certbot certonly --standalone --noninteractive --agree-tos \
 			--rsa-key-size 4096 \
-			--domain ${API_DOMAIN} \
-			--email ${CERT_ADMIN_EMAIL}
+			--domain ${API_DOMAIN}
 	fi
 }
 

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -26,7 +26,6 @@ ENV MODULE_NAME=nginx \
     DOLLAR=$ \
     TZ=UTC \
     SSL_CERT_MODE=Yes \
-    CERT_ADMIN_EMAIL=example@example.com \
     NGINX_HTTP2=http2 \
     NGINX_CLIENT_BODY_SIZE=30 \
     NGINX_ADMIN_ALLOW_NETWORK=all \


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Fixes #556

## Description of Changes

Removed CERT_ADMIN_EMAIL setting as Let's Encrypt no long sends expiration email to the user.

