### PR TITLE
[fix] Added loud failure message if existing database is detected #562

### DIFF
--- a/deploy/auto-install.sh
+++ b/deploy/auto-install.sh
@@ -103,6 +103,44 @@ setup_docker_openwisp() {
 	echo -ne ${GRN}"Do you have .env file? Enter filepath (leave blank for ad-hoc configuration): "${NON}
 	read env_path
 	if [[ ! -f "$env_path" ]]; then
+		# Validate backup has required credentials
+		backup_has_credentials=false
+		if [[ -f "$ENV_BACKUP" ]]; then
+			backup_has_credentials=true
+			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
+				if [[ -z "$(get_env "$config" "$ENV_BACKUP")" ]]; then
+					backup_has_credentials=false
+					break
+				fi
+			done
+		fi
+		
+		if [[ ! -f "$INSTALL_PATH/.env" ]] && [[ "$backup_has_credentials" != true ]] && docker volume inspect "docker-openwisp_postgres_data" &>/dev/null; then
+			{
+				echo -e "${RED}CRITICAL: Existing database volume detected!${NON}"
+				echo ""
+				echo "The Docker volume \"docker-openwisp_postgres_data\" already exists on this system."
+				echo "This likely means there is database data from a previous OpenWISP installation."
+				echo ""
+				echo "The auto-install script generates new database credentials during fresh installations."
+				echo "If it proceeds while this volume exists, the newly generated credentials will not"
+				echo "match the credentials stored in the existing database, making the database"
+				echo "inaccessible to OpenWISP."
+				echo ""
+				echo -e "${RED}⚠️  WARNING: The commands below will permanently delete the database volume and all"
+				echo -e "stored data. Run them only if you intentionally want to wipe the previous installation"
+				echo -e "or have a verified backup. Proceed at your own discretion.${NON}"
+				echo ""
+				echo "Cleanup commands:"
+				echo -e "  ${YLW}cd /opt/openwisp/docker-openwisp && docker compose down --volumes${NON}"
+				echo "or"
+				echo -e "  ${YLW}docker volume rm docker-openwisp_postgres_data${NON}"
+				echo ""
+				echo "Aborting installation to prevent credential mismatch."
+				echo -e "${RED}Check logs at $LOG_FILE${NON}"
+			} | tee -a "$LOG_FILE"
+			exit 1
+		fi
 		# Dashboard Domain
 		echo -ne ${GRN}"(1/5) Enter dashboard domain: "${NON}
 		read dashboard_domain
@@ -157,9 +195,27 @@ setup_docker_openwisp() {
 		fi
 		# Site manager email
 		set_env "EMAIL_DJANGO_DEFAULT" "$django_default_email"
-		# Set random secret values
-		python3 $INSTALL_PATH/build.py change-secret-key >/dev/null
-		python3 $INSTALL_PATH/build.py change-database-credentials >/dev/null
+		# Re-validate backup credentials after download
+		restore_from_backup=false
+		if [[ -f "$ENV_BACKUP" ]]; then
+			restore_from_backup=true
+			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
+				if [[ -z "$(get_env "$config" "$ENV_BACKUP")" ]]; then
+					restore_from_backup=false
+					break
+				fi
+			done
+		fi
+		# Set random secret values only if no previous credentials exist
+		if [[ "$restore_from_backup" == true ]]; then
+			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
+				value=$(get_env "$config" "$ENV_BACKUP")
+				set_env "$config" "$value"
+			done
+		else
+			python3 $INSTALL_PATH/build.py change-secret-key >/dev/null
+			python3 $INSTALL_PATH/build.py change-database-credentials >/dev/null
+		fi
 		# SSL Configuration
 		use_letsencrypt_lower=$(echo "$use_letsencrypt" | tr '[:upper:]' '[:lower:]')
 		if [[ "$use_letsencrypt_lower" == "y" || "$use_letsencrypt_lower" == "yes" ]]; then

--- a/deploy/auto-install.sh
+++ b/deploy/auto-install.sh
@@ -36,6 +36,14 @@ check_status() {
 	fi
 }
 
+# Returns true if the backup .env exists and contains app secrets
+has_backup_with_secrets() {
+	[[ -f "$ENV_BACKUP" ]] && \
+	[[ -n "$(get_env "DB_USER" "$ENV_BACKUP")" ]] && \
+	[[ -n "$(get_env "DB_PASS" "$ENV_BACKUP")" ]] && \
+	[[ -n "$(get_env "DJANGO_SECRET_KEY" "$ENV_BACKUP")" ]]
+}
+
 error_msg() {
 	report_error
 	echo -e ${RED}${1}${NON}
@@ -103,41 +111,16 @@ setup_docker_openwisp() {
 	echo -ne ${GRN}"Do you have .env file? Enter filepath (leave blank for ad-hoc configuration): "${NON}
 	read env_path
 	if [[ ! -f "$env_path" ]]; then
-		# Validate backup has required credentials
-		backup_has_credentials=false
-		if [[ -f "$ENV_BACKUP" ]]; then
-			backup_has_credentials=true
-			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
-				if [[ -z "$(get_env "$config" "$ENV_BACKUP")" ]]; then
-					backup_has_credentials=false
-					break
-				fi
-			done
-		fi
-		
-		if [[ ! -f "$INSTALL_PATH/.env" ]] && [[ "$backup_has_credentials" != true ]] && docker volume inspect "docker-openwisp_postgres_data" &>/dev/null; then
+		# Prevent issues when users reinstall carelessly
+		if [[ ! -f "$INSTALL_PATH/.env" ]] && ! has_backup_with_secrets && docker volume inspect "docker-openwisp_postgres_data" &>/dev/null; then
 			{
-				echo -e "${RED}CRITICAL: Existing database volume detected!${NON}"
+				echo -e "${RED}ERROR: Database volume exists but .env is missing.${NON}"
 				echo ""
-				echo "The Docker volume \"docker-openwisp_postgres_data\" already exists on this system."
-				echo "This likely means there is database data from a previous OpenWISP installation."
+				echo "Generating new credentials would break access to the existing database."
 				echo ""
-				echo "The auto-install script generates new database credentials during fresh installations."
-				echo "If it proceeds while this volume exists, the newly generated credentials will not"
-				echo "match the credentials stored in the existing database, making the database"
-				echo "inaccessible to OpenWISP."
-				echo ""
-				echo -e "${RED}⚠️  WARNING: The commands below will permanently delete the database volume and all"
-				echo -e "stored data. Run them only if you intentionally want to wipe the previous installation"
-				echo -e "or have a verified backup. Proceed at your own discretion.${NON}"
-				echo ""
-				echo "Cleanup commands:"
-				echo -e "  ${YLW}cd /opt/openwisp/docker-openwisp && docker compose down --volumes${NON}"
-				echo "or"
-				echo -e "  ${YLW}docker volume rm docker-openwisp_postgres_data${NON}"
-				echo ""
-				echo "Aborting installation to prevent credential mismatch."
-				echo -e "${RED}Check logs at $LOG_FILE${NON}"
+				echo "Option 1 - Restore your previous .env and re-run this script."
+				echo "Option 2 - Wipe the database and start fresh (ALL DATA WILL BE LOST), e.g.:"
+				echo -e "  ${YLW}cd $INSTALL_PATH && docker compose down --volumes${NON}"
 			} | tee -a "$LOG_FILE"
 			exit 1
 		fi
@@ -195,19 +178,8 @@ setup_docker_openwisp() {
 		fi
 		# Site manager email
 		set_env "EMAIL_DJANGO_DEFAULT" "$django_default_email"
-		# Re-validate backup credentials after download
-		restore_from_backup=false
-		if [[ -f "$ENV_BACKUP" ]]; then
-			restore_from_backup=true
-			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
-				if [[ -z "$(get_env "$config" "$ENV_BACKUP")" ]]; then
-					restore_from_backup=false
-					break
-				fi
-			done
-		fi
-		# Set random secret values only if no previous credentials exist
-		if [[ "$restore_from_backup" == true ]]; then
+		# Set new secrets only if not previously set
+		if has_backup_with_secrets; then
 			for config in DB_USER DB_PASS DJANGO_SECRET_KEY; do
 				value=$(get_env "$config" "$ENV_BACKUP")
 				set_env "$config" "$value"


### PR DESCRIPTION
## Checklist
- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue
Closes #562

## Description of Changes

The auto-install script was silently regenerating database credentials on every run, which broke existing setups when users reinstalled without clearing volumes. This caused the "FATAL: password authentication failed" error reported in #562.

I've added a simple check that detects when postgres volumes exist but the .env file is missing. When this happens, the script now stops and shows a clear warning with instructions on how to proceed safely.

The fix follows the approach discussed in the issue - no automatic volume deletion, just a red warning and the command users need to run manually if they want to start fresh.

## Screenshot
N/A
