### PR TITLE
[openvpn] Decouple VPN_NAME from openvpn process config #572

### DIFF
--- a/images/common/init_command.sh
+++ b/images/common/init_command.sh
@@ -29,7 +29,10 @@ elif [ "$MODULE_NAME" = 'freeradius' ]; then
 		source docker-entrypoint.sh -X
 	fi
 elif [ "$MODULE_NAME" = 'openvpn' ]; then
-	if [[ -z "$VPN_DOMAIN" ]]; then exit; fi
+        if [ -z "$VPN_DOMAIN" ]; then
+            echo "WARNING: VPN_DOMAIN not set, skipping OpenVPN setup" >&2
+            exit 0
+        fi
 	wait_nginx_services
 	openvpn_preconfig
 	openvpn_config


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #572.

## Description of Changes

**Problem:** Supervisord fails to start the OpenVPN process if the `VPN_NAME` environment variable contains whitespace.

**Root Cause:** The `VPN_NAME` environment variable is directly interpolated into the process manager command without escaping, breaking execution when spaces are present. This creates a tight coupling between the UI-defined object name and internal OS process execution.

**Fix:** Decoupled the internal process management from the environment variable. 
1. Hardcoded `supervisord.conf` to target a static `openvpn.conf` file.
2. Implemented dynamic file discovery in `openvpn_config_download` (`utils.sh`) to automatically identify and standardize the extracted configuration filename.

**Side-Effects:** Evaluated side effects and system impact; no adverse effects on network routing. The OpenVPN interface remains safely bound to `tun0` as configured in `openvpn.json`.

## Screenshot

N/A