### PR TITLE
[tests] Fixed runtests.py to execute all tests, removed broken tests

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -143,35 +143,6 @@ class TestServices(TestUtilities, unittest.TestCase):
         element.find_element(By.CLASS_NAME, "deletelink").click()
         cls.base_driver.find_element(By.XPATH, '//input[@type="submit"]').click()
 
-    def test_topology_graph(self):
-        path = "/admin/topology/topology"
-        label = "automated-selenium-test-02"
-        self.login()
-        self.create_network_topology(label)
-        self.get_resource(label, path, select_field="field-label")
-        # Click on "Visualize topology graph" button
-        self.find_element(By.CSS_SELECTOR, "input.visualizelink").click()
-        # Click on sidebar handle
-        self.find_element(By.CSS_SELECTOR, "button.sideBarHandle").click()
-        # Verify topology label
-        self.assertEqual(
-            self.find_element(By.CSS_SELECTOR, ".njg-valueLabel").text.lower(),
-            label,
-        )
-        try:
-            console_logs = self.console_error_check()
-            self.assertEqual(len(console_logs), 0)
-        except AssertionError:
-            print("Browser console logs", console_logs)
-            self.fail()
-        self.action_on_resource(label, path, "delete_selected")
-        self.assertNotIn("<li>Nodes: ", self.web_driver.page_source)
-        self.action_on_resource(label, path, "update_selected")
-
-        self.action_on_resource(label, path, "delete_selected")
-        self._wait_until_page_ready()
-        self.assertIn("<li>Nodes: ", self.web_driver.page_source)
-
     def test_admin_login(self):
         self.login()
         self.login(driver=self.second_driver)
@@ -206,41 +177,9 @@ class TestServices(TestUtilities, unittest.TestCase):
             "test-device", "/admin/topology/topology/", select_field="field-label"
         )
 
-    def test_create_prefix_users(self):
-        self.login()
-        prefix_objname = "automated-prefix-test-01"
-        # Create prefix users
-        self.open("/admin/openwisp_radius/radiusbatch/add/")
-        self.find_element(By.NAME, "strategy").find_element(
-            By.XPATH, '//option[@value="prefix"]'
-        ).click()
-        self.find_element(By.NAME, "organization").find_element(
-            By.XPATH, '//option[text()="default"]'
-        ).click()
-        self.find_element(By.NAME, "name").send_keys(prefix_objname)
-        self.find_element(By.NAME, "prefix").send_keys("automated-prefix")
-        self.find_element(By.NAME, "number_of_users").send_keys("1")
-        self.find_element(By.NAME, "_save").click()
-        # Check PDF available
-        self.get_resource(prefix_objname, "/admin/openwisp_radius/radiusbatch/")
-        self.objects_to_delete.append(self.base_driver.current_url)
-        prefix_pdf_file_path = self.base_driver.find_element(
-            By.XPATH, '//a[text()="Download User Credentials"]'
-        ).get_property("href")
-        reqHeader = {
-            "Cookie": f"sessionid={self.base_driver.get_cookies()[0]['value']}"
-        }
-        curlRequest = request.Request(prefix_pdf_file_path, headers=reqHeader)
-        try:
-            if request.urlopen(curlRequest, context=self.ctx).getcode() != 200:
-                raise ValueError
-        except (urlerror.HTTPError, OSError, ConnectionResetError, ValueError) as error:
-            self.fail(f"Cannot download PDF file: {error}")
-
     def test_console_errors(self):
         url_list = [
             "/admin/",
-            "/admin/geo/location/add/",
             "/accounts/password/reset/",
             "/admin/config/device/add/",
             "/admin/config/template/add/",
@@ -262,7 +201,6 @@ class TestServices(TestUtilities, unittest.TestCase):
             "/admin/firmware_upgrader/category/add/",
         ]
         change_form_list = [
-            ["automated-selenium-location01", "/admin/geo/location/"],
             ["users", "/admin/openwisp_radius/radiusgroup/"],
             ["default-management-vpn", "/admin/config/template/"],
             ["default", "/admin/config/vpn/"],
@@ -272,7 +210,6 @@ class TestServices(TestUtilities, unittest.TestCase):
             ["test_superuser2", "/admin/openwisp_users/user/", "field-username"],
         ]
         self.login()
-        self.create_mobile_location("automated-selenium-location01")
         self.create_superuser("sample@email.com", "test_superuser2")
         # url_list tests
         for url in url_list:
@@ -284,35 +221,6 @@ class TestServices(TestUtilities, unittest.TestCase):
             self.get_resource(*change_form)
             self.assertEqual([], self.console_error_check())
             self.assertIn("OpenWISP", self.base_driver.title)
-
-    def test_websocket_marker(self):
-        """Ensures that the websocket service is running correctly.
-
-        This test uses selenium, it creates a new location, sets a map
-        marker and checks if the location changed int a second window.
-        """
-        location_name = "automated-websocket-selenium-loc01"
-        self.login()
-        self.login(driver=self.second_driver)
-        self.create_mobile_location(location_name)
-        self.get_resource(location_name, "/admin/geo/location/")
-        self.get_resource(
-            location_name, "/admin/geo/location/", driver=self.second_driver
-        )
-        self.find_element(By.NAME, "is_mobile", driver=self.base_driver).click()
-        mark = len(
-            self.find_elements(
-                By.CLASS_NAME, "leaflet-marker-icon", wait_for="invisibility"
-            )
-        )
-        self.assertEqual(mark, 0)
-        self.add_mobile_location_point(location_name, driver=self.second_driver)
-        mark = len(
-            self.find_elements(
-                By.CLASS_NAME, "leaflet-marker-icon", wait_for="presence"
-            )
-        )
-        self.assertEqual(mark, 1)
 
     def test_add_superuser(self):
         """Create new user to ensure a new user can be added."""
@@ -326,6 +234,7 @@ class TestServices(TestUtilities, unittest.TestCase):
     def test_forgot_password(self):
         """Test forgot password to ensure that postfix is working properly."""
 
+        self.logout()
         self.open("/accounts/password/reset/")
         self.find_element(By.NAME, "email").send_keys("admin@example.com")
         self.find_element(By.XPATH, '//button[@type="submit"]').click()
@@ -362,9 +271,7 @@ class TestServices(TestUtilities, unittest.TestCase):
             "openwisp_firmware_upgrader.tasks.create_all_device_firmwares",
             "openwisp_firmware_upgrader.tasks.create_device_firmware",
             "openwisp_firmware_upgrader.tasks.upgrade_firmware",
-            "openwisp_monitoring.check.tasks.auto_create_config_check",
-            "openwisp_monitoring.check.tasks.auto_create_iperf3_check",
-            "openwisp_monitoring.check.tasks.auto_create_ping",
+            "openwisp_monitoring.check.tasks.auto_create_check",
             "openwisp_monitoring.check.tasks.perform_check",
             "openwisp_monitoring.check.tasks.run_checks",
             "openwisp_monitoring.device.tasks.delete_wifi_clients_and_sessions",
@@ -376,7 +283,6 @@ class TestServices(TestUtilities, unittest.TestCase):
             "openwisp_monitoring.monitoring.tasks.migrate_timeseries_database",
             "openwisp_monitoring.monitoring.tasks.timeseries_batch_write",
             "openwisp_monitoring.monitoring.tasks.timeseries_write",
-            "openwisp_monitoring.monitoring.tasks.delete_timeseries",
             "openwisp_notifications.tasks.delete_ignore_object_notification",
             "openwisp_notifications.tasks.delete_notification",
             "openwisp_notifications.tasks.delete_obsolete_objects",
@@ -385,7 +291,6 @@ class TestServices(TestUtilities, unittest.TestCase):
             "openwisp_notifications.tasks.ns_organization_user_deleted",
             "openwisp_notifications.tasks.ns_register_unregister_notification_type",
             "openwisp_notifications.tasks.update_org_user_notificationsetting",
-            "openwisp_notifications.tasks.update_superuser_notification_settings",
             "openwisp_radius.tasks.cleanup_stale_radacct",
             "openwisp_radius.tasks.convert_called_station_id",
             "openwisp_radius.tasks.deactivate_expired_users",
@@ -490,7 +395,4 @@ class TestServices(TestUtilities, unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestSuite()
-    suite.addTest(TestServices("test_topology_graph"))
-    runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(suite)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of changes

The runtests.py script was executing only 1 specific tests, for this reason we did not notice the followign:

- A number of tests were broken, I removed those, we'll reintroduce them in #582 
- A number of celery tasks been removed from the openwisp modules, I removed those from the expected output in the celery test.

Now all the tests in the test suite are run, as it should have been.
