### PR TITLE
[fix] Corrected TOPOLOGY_UPDATE_INTERVAL typo in OpenVPN config

### DIFF
--- a/images/common/utils.sh
+++ b/images/common/utils.sh
@@ -257,6 +257,6 @@ function init_send_network_topology {
 	fi
 	(
 		crontab -l
-		echo "*/$TOPLOGY_UPDATE_INTERVAL * * * * TOPOLOGY_UUID=$TOPOLOGY_UUID TOPOLOGY_KEY=$TOPOLOGY_KEY sh /send-topology.sh"
+		echo "*/$TOPOLOGY_UPDATE_INTERVAL * * * * TOPOLOGY_UUID=$TOPOLOGY_UUID TOPOLOGY_KEY=$TOPOLOGY_KEY sh /send-topology.sh"
 	) | crontab -
 }

--- a/images/openwisp_openvpn/Dockerfile
+++ b/images/openwisp_openvpn/Dockerfile
@@ -25,7 +25,7 @@ ENV MODULE_NAME=openvpn \
     DB_SSLCERT=None \
     DB_SSLROOTCERT=None \
     DB_OPTIONS={} \
-    TOPLOGY_UPDATE_INTERVAL=3
+    TOPOLOGY_UPDATE_INTERVAL=3
 
 # hadolint ignore=DL3045
 COPY ./common/init_command.sh \


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code. *(N/A - typo fix)*
- [x] I have updated the documentation. *(N/A - making code match existing docs)*

## Reference to Existing Issue

*(No existing issue - minor typo fix)*

## Description of Changes

This PR fixes a typo where `TOPOLOGY_UPDATE_INTERVAL` was misspelled as `TOPLOGY_UPDATE_INTERVAL` in `images/openwisp_openvpn/Dockerfile` and `images/common/utils.sh`. 

Because of this spelling error, the OpenVPN cron job generation in `utils.sh` was looking for a variable that did not match the official documentation. This caused any user-defined interval in `.env` to be silently ignored, forcing the system to fall back to the default of 3 minutes.

This PR renames the variable to `TOPOLOGY_UPDATE_INTERVAL` to match the official documentation, ensuring user configurations are properly applied to the `send-topology.sh` cron job.
