### PR TITLE
[tests] Removed map(str, ...) that overrides properly decoded stdout/…

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -90,7 +90,6 @@ class TestServices(TestUtilities, unittest.TestCase):
         else:
             output = cmd.stdout.decode("utf-8", errors="replace") if cmd.stdout else ""
             error = cmd.stderr.decode("utf-8", errors="replace") if cmd.stderr else ""
-        output, error = map(str, (cmd.stdout, cmd.stderr))
         with open(cls.config["logs_file"], "a") as logs_file:
             logs_file.write(output)
             logs_file.write(error)
@@ -207,7 +206,7 @@ class TestServices(TestUtilities, unittest.TestCase):
                 stderr=subprocess.PIPE,
                 cwd=cls.root_location,
             )
-            output, _ = map(str, cmd.communicate())
+            output, _ = cmd.communicate()
             print(f"One of the containers are down!\nOutput:\n{output}")
 
     @classmethod
@@ -482,7 +481,7 @@ class TestServices(TestUtilities, unittest.TestCase):
             stderr=subprocess.PIPE,
             cwd=self.root_location,
         )
-        output, error = map(str, cmd.communicate())
+        output, error = cmd.communicate()
         if "Exit" in output:
             self.fail(
                 f"One of the containers are down!\nOutput:\n{output}\nError:\n{error}"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code. *(N/A - fixing test runner output)*
- [ ] I have updated the documentation. *(N/A)*

## Description of Changes

This PR fixes a bug in `tests/runtests.py` where the test runner output logs were being corrupted by unnecessary `str()` typecasting on raw `bytes` objects. 

**The Issue:**
In `_execute_docker_compose_command`, `cmd.stdout` and `cmd.stderr` are retrieved as raw `bytes` (since `use_text_mode=False`). 
The code correctly decoded these into UTF-8 strings (`output = cmd.stdout.decode("utf-8")`), but then immediately executed `output, error = map(str, (cmd.stdout, cmd.stderr))`. 

Calling `str()` directly on a bytes object does not decode it; instead, it creates a literal string representation (e.g., `"b'Starting container...\\n'"`). This escaped all newlines and wrapped every output line in `b'...'`, making the docker compose test logs highly unreadable.

**The Fix:**
1. Removed `output, error = map(str, (cmd.stdout, cmd.stderr))` from `_execute_docker_compose_command` so the properly decoded UTF-8 strings are preserved and written to the log file.
2. Removed redundant `map(str, cmd.communicate())` calls in `tearDownClass` and `test_containers_down`. In these cases, `universal_newlines=True` was used, so `communicate()` already returns strings, making the `map(str, ...)` call unnecessary dead code.

## Screenshot

*(N/A - Terminal output fix)*
