### PR TITLE
[fix] Dynamically inject __openwisp_version__ into immutable file at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,14 @@ base-build:
 	done; \
 	docker build --tag openwisp/openwisp-base:intermedia-system \
 	             --file ./images/openwisp_base/Dockerfile \
-	             --target SYSTEM ./images/; \
+	             --target system ./images/; \
 	docker build --tag openwisp/openwisp-base:intermedia-python \
 	             --file ./images/openwisp_base/Dockerfile \
-	             --target PYTHON ./images/ \
+	             --target openwisp_python ./images/ \
 	             $$BUILD_ARGS; \
 	docker build --tag $(IMAGE_OWNER)/openwisp-base:$(OPENWISP_VERSION) \
 	             --file ./images/openwisp_base/Dockerfile ./images/ \
+	             --build-arg OPENWISP_VERSION=$(OPENWISP_VERSION) \
 	             $$BUILD_ARGS
 
 nfs-build:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ base-build:
 	             $$BUILD_ARGS; \
 	docker build --tag $(IMAGE_OWNER)/openwisp-base:$(OPENWISP_VERSION) \
 	             --file ./images/openwisp_base/Dockerfile ./images/ \
-	             --build-arg OPENWISP_VERSION=$(OPENWISP_VERSION) \
+	             --build-arg OPENWISP_VERSION="$(OPENWISP_VERSION)" \
 	             $$BUILD_ARGS
 
 nfs-build:

--- a/images/common/openwisp/__init__.py
+++ b/images/common/openwisp/__init__.py
@@ -1,7 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
+import os
+
 from .celery import app as celery_app
 
 __all__ = ["celery_app"]
-__openwisp_version__ = "25.10.0"
+
+try:
+    with open(os.path.join(os.path.dirname(__file__), ".version-info"), "r") as f:
+        __openwisp_version__ = f.read().strip()
+except FileNotFoundError:
+    __openwisp_version__ = "unknown"
+
 __openwisp_installation_method__ = "docker-openwisp"

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -98,6 +98,9 @@ RUN chown -R openwisp:root /opt/openwisp && \
 # Maintain backward compatibility with code written for ansible-openwisp2
 RUN ln -s /opt/openwisp/openwisp /opt/openwisp/openwisp2
 
+ARG OPENWISP_VERSION=unknown
+RUN printf "%s\n" "${OPENWISP_VERSION}" > /opt/openwisp/openwisp/.version-info
+
 ENV DASHBOARD_APP_SERVICE=dashboard \
     PYTHONUNBUFFERED=1 \
     TZ=UTC \

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -341,6 +341,25 @@ class TestServices(TestUtilities, unittest.TestCase):
             self.base_driver.page_source,
         )
 
+    def test_openwisp_version(self):
+        """Ensure __openwisp_version__ is properly injected and readable."""
+        container_id = self.docker_compose_get_container_id("dashboard")
+        dashboard_container = self.docker_client.containers.get(container_id)
+        
+        # 1. Verify python module reads the version correctly and it's not unknown
+        result = dashboard_container.exec_run(
+            'python -c "import openwisp; print(openwisp.__openwisp_version__)"'
+        )
+        self.assertEqual(result.exit_code, 0)
+        python_version = result.output.decode("utf-8").strip()
+        self.assertNotEqual(python_version, "unknown")
+        
+        # 2. Verify .version-info file exists and matches
+        result_file = dashboard_container.exec_run("cat /opt/openwisp/openwisp/.version-info")
+        self.assertEqual(result_file.exit_code, 0)
+        file_version = result_file.output.decode("utf-8").strip()
+        self.assertEqual(python_version, file_version)
+
     def test_celery(self):
         """Ensure celery and celery-beat tasks are registered."""
         expected_output_list = [

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -351,7 +351,7 @@ class TestServices(TestUtilities, unittest.TestCase):
             'python -c "import openwisp; print(openwisp.__openwisp_version__)"'
         )
         self.assertEqual(result.exit_code, 0)
-        python_version = result.output.decode("utf-8").strip()
+        python_version = result.output.decode("utf-8").strip().splitlines()[-1]
         self.assertNotEqual(python_version, "unknown")
 
         # 2. Verify .version-info file exists and matches

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -345,7 +345,7 @@ class TestServices(TestUtilities, unittest.TestCase):
         """Ensure __openwisp_version__ is properly injected and readable."""
         container_id = self.docker_compose_get_container_id("dashboard")
         dashboard_container = self.docker_client.containers.get(container_id)
-        
+
         # 1. Verify python module reads the version correctly and it's not unknown
         result = dashboard_container.exec_run(
             'python -c "import openwisp; print(openwisp.__openwisp_version__)"'
@@ -353,9 +353,11 @@ class TestServices(TestUtilities, unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         python_version = result.output.decode("utf-8").strip()
         self.assertNotEqual(python_version, "unknown")
-        
+
         # 2. Verify .version-info file exists and matches
-        result_file = dashboard_container.exec_run("cat /opt/openwisp/openwisp/.version-info")
+        result_file = dashboard_container.exec_run(
+            "cat /opt/openwisp/openwisp/.version-info"
+        )
         self.assertEqual(result_file.exit_code, 0)
         file_version = result_file.output.decode("utf-8").strip()
         self.assertEqual(python_version, file_version)


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #570.

## Description of Changes

This PR resolves the version staleness issue by establishing a robust, immutable way to inject `__openwisp_version__` into the Docker images without triggering syntax injection risks or UI test timeouts.

1. **Dockerfile:** Used `ARG OPENWISP_VERSION` and `printf` to write the version directly into a plain text `/opt/openwisp/openwisp/.version-info` file during the final build step.
2. **Makefile:** Fixed the broken `--target SYSTEM` and `--target PYTHON` flags (changed to `system` and `openwisp_python`) so the Docker cache correctly picks up the stages, and explicitly passed `--build-arg OPENWISP_VERSION`.
3. **__init__.py:** Replaced the hardcoded version with a safe `try/except FileNotFoundError` block that reads `.version-info`. This strictly eliminates `.env` runtime override bugs, avoids Python string-escaping vulnerabilities, and gracefully degrades to `"unknown"` outside of Docker to prevent Selenium tests from throwing `ImportError` timeouts in CI.
