### PR TITLE
[ci] Prevent stale test data from poisoning CI retries #621

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,21 @@ jobs:
           # /opt/openwisp/docker-openwisp. To ensure the test runs correctly
           # and environment variables remain intact, it is essential to
           # execute the test from this directory.
-          command: cd /opt/openwisp/docker-openwisp && make develop-pythontests && make stop
+          command: cd /opt/openwisp/docker-openwisp && make develop-pythontests
         env:
           SELENIUM_HEADLESS: 1
 
       - name: Print docker logs
         if: ${{ failure() }}
         run: docker compose logs
+
+      - name: Stop containers
+        # Run teardown exactly once after the retry loop, regardless of the
+        # test outcome. Keeping `make stop` out of the retried command ensures
+        # a failed attempt never skips teardown and never tears the stack down
+        # between retries (which would make every subsequent retry fail).
+        if: ${{ always() && steps.auto_install_upgrade.conclusion == 'success' }}
+        run: cd /opt/openwisp/docker-openwisp && make stop
 
       # the following action is equivalent to
       # echo "$DOCKER_HUB_SECRET" | docker login --username "$DOCKER_HUB_USERNAME" --password-stdin

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -6,7 +6,7 @@ from urllib import error as urlerror
 from urllib import request
 
 import requests
-from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -143,6 +143,43 @@ class TestServices(TestUtilities, unittest.TestCase):
         )
 
     @classmethod
+    def _cleanup_stale_test_data(cls):
+        """Delete test-created users that may remain from a previous failed run.
+
+        Runs before tests start so each CI attempt begins with a clean
+        slate. Uses the Django ORM directly (via docker compose exec) to
+        avoid any Selenium dependency during setup.
+        """
+        try:
+            cls._execute_docker_compose_command(
+                [
+                    "docker",
+                    "compose",
+                    "exec",
+                    "-T",
+                    "dashboard",
+                    "python",
+                    "manage.py",
+                    "shell",
+                    "-c",
+                    (
+                        "from openwisp_users.models import User; "
+                        "User.objects.filter("
+                        "username__in=['signup-user', 'test_superuser', "
+                        "'test_superuser2']"
+                        ").delete()"
+                    ),
+                ],
+                use_text_mode=True,
+            )
+        except Exception as e:
+            exc_type = type(e).__name__
+            print(
+                f"Warning: stale test data cleanup failed ({exc_type}: {e}). "
+                "Individual tests may fail if stale data is present."
+            )
+
+    @classmethod
     def setUpClass(cls):
         cls.failed_test = False
         cls.live_server_url = cls.config["app_url"]
@@ -171,6 +208,7 @@ class TestServices(TestUtilities, unittest.TestCase):
                 ["docker", "compose", "up", "--detach"],
             )
         cls._setup_admin_theme_links()
+        cls._cleanup_stale_test_data()
         # Create base drivers (Firefox)
         if cls.config["driver"] == "firefox":
             cls.base_driver = cls.get_firefox_webdriver()
@@ -186,8 +224,9 @@ class TestServices(TestUtilities, unittest.TestCase):
         for resource_link in cls.objects_to_delete:
             try:
                 cls._delete_object(resource_link)
-            except NoSuchElementException:
-                print(f"Unable to delete resource at: {resource_link}")
+            except Exception as e:
+                exc_type = type(e).__name__
+                print(f"Unable to delete resource at {resource_link}: {exc_type}: {e}")
         cls.second_driver.quit()
         cls.base_driver.quit()
         # Remove the temporary custom CSS file created for testing
@@ -419,7 +458,7 @@ class TestServices(TestUtilities, unittest.TestCase):
 
     def test_radius_user_registration(self):
         """Ensure users can register using the RADIUS API."""
-        url = f'{self.config["api_url"]}/api/v1/radius/organization/default/account/'
+        url = f"{self.config['api_url']}/api/v1/radius/organization/default/account/"
         response = requests.post(
             url,
             json={


### PR DESCRIPTION
A transient Selenium timeout in tearDownClass left signup-user, test_superuser, and test_superuser2 in the database. Because `make stop` is `&&` chained after `make runtests`, a non-zero exit skipped cleanup, so every subsequent CI retry re-POSTed against dirty state and failed deterministically.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #621 .

## Description of Changes
1. Pre-run cleanup — `setUpClass` now calls `_cleanup_stale_test_data()` before creating any Selenium drivers. It deletes the three known test users via the Django ORM (manage.py shell) with no Selenium dependency, so each CI attempt always starts from a clean slate regardless of what the previous attempt left behind.
2. Resilient teardown — `tearDownClass` now catches Exception (not just NoSuchElementException) from `_delete_object`, logs the full exception type and message, and continues. A transient network or driver timeout no longer crashes teardown and causes make stop to be skipped.