### PR TITLE
[change] Decoupled expired-user deactivation from USE_OPENWISP_RADIUS…

### DIFF
--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -462,8 +462,10 @@ framework.
 ``CRON_DELETE_OLD_RADIUSBATCH_USERS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- **Explanation:** (Value in days) Deactivates expired user accounts which
-  were created temporarily and have an expiration date set.
+- **Explanation:** (Value in days) Deletes RADIUS batch users (created
+  temporarily via RADIUS batch operations) older than the given number of
+  days. Expired-account *deactivation* is handled automatically by
+  openwisp-users and no longer depends on ``USE_OPENWISP_RADIUS``.
 - **Valid Values:** INTEGER.
 - **Default:** ``365``.
 

--- a/images/common/openwisp/celery.py
+++ b/images/common/openwisp/celery.py
@@ -80,6 +80,17 @@ notification_schedule = {
     },
 }
 
+users_schedule = {
+    "deactivate-expired-users": {
+        "task": "openwisp_users.tasks.deactivate_expired_users",
+        "schedule": crontab(hour=0, minute=1),
+    },
+    "expiration-reminder-email": {
+        "task": "openwisp_users.tasks.expiration_reminder_email",
+        "schedule": crontab(hour=0, minute=5),
+    },
+}
+
 if not os.environ.get("USE_OPENWISP_CELERY_TASK_ROUTES_DEFAULTS", True):
     task_routes = {}
 
@@ -91,6 +102,7 @@ app = Celery(
         **radius_schedule,
         **topology_schedule,
         **notification_schedule,
+        **users_schedule,
         **monitoring_schedule,
         **metric_collection_schedule,
     },

--- a/images/common/openwisp/tasks.py
+++ b/images/common/openwisp/tasks.py
@@ -17,7 +17,6 @@ def radius_tasks():
     management.call_command(
         "cleanup_stale_radacct", int(os.environ["CRON_CLEANUP_STALE_RADACCT"])
     )
-    management.call_command("deactivate_expired_users")
     management.call_command(
         "delete_old_radiusbatch_users",
         older_than_days=int(os.environ["CRON_DELETE_OLD_RADIUSBATCH_USERS"]),

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -427,13 +427,14 @@ class TestServices(TestUtilities, unittest.TestCase):
             "openwisp_notifications.tasks.update_org_user_notificationsetting",
             "openwisp_radius.tasks.cleanup_stale_radacct",
             "openwisp_radius.tasks.convert_called_station_id",
-            "openwisp_radius.tasks.deactivate_expired_users",
             "openwisp_radius.tasks.delete_old_postauth",
             "openwisp_radius.tasks.delete_old_radacct",
             "openwisp_radius.tasks.delete_old_radiusbatch_users",
             "openwisp_radius.tasks.delete_unverified_users",
             "openwisp_radius.tasks.perform_change_of_authorization",
             "openwisp_radius.tasks.send_login_email",
+            "openwisp_users.tasks.deactivate_expired_users",
+            "openwisp_users.tasks.expiration_reminder_email",
         ]
 
         def _test_celery_task_registered(container_name):


### PR DESCRIPTION
Scheduled `openwisp_users.tasks.deactivate_expired_users` and `expiration_reminder_email` always-on in the Celery beat schedule, so user expiry handling no longer depends on the RADIUS module being enabled. Removed the obsolete `deactivate_expired_users` management command called from `radius_tasks()`.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #587

## Description of Changes
  - Pinned the whole interdependent OpenWISP core to the 1.3 branch in `images/openwisp_base/Dockerfile`. The 1.3 line moved to openwisp-utils 1.3 (which removed UUIDAdmin), so the modules must move as one unit to avoid the dashboard `ImportError` crash-loop. Temporary, revert to ~=1.x pins once 1.3 is released.
  - Fixed `create_ssh_key_template()` in `load_init_data.py` to dedupe by template name instead of `config__contains`. Controller 1.3 migrated config to a JSONB field, where `__contains` is containment (not a substring match), which broke idempotency and crash-looped the dashboard on restart against a populated DB.
- Updated `tests/runtests.py` task assertions
- Corrected the `CRON_DELETE_OLD_RADIUSBATCH_USERS` description in `docs/user/settings.rst`.