### PR TITLE
[tests] Fixed isolation bugs in functional tests and updated tests broken due to changes in openwisp-utils

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -12,10 +12,11 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from utils import TestUtilities
+from utils import BaseTestUtils, SeleniumTestUtils
 
 
-class Pretest(TestUtilities, unittest.TestCase):
+# 0 in the name is on purpose for alphabetical discovery
+class Test0Preconditions(BaseTestUtils, unittest.TestCase):
     """Checks to perform before tests"""
 
     def test_wait_for_services(self):
@@ -60,7 +61,7 @@ class Pretest(TestUtilities, unittest.TestCase):
             self.fail(f"All celery workers are not online: {online_workers}")
 
 
-class TestServices(TestUtilities, unittest.TestCase):
+class TestServices(SeleniumTestUtils, unittest.TestCase):
     custom_static_token = None
 
     @property
@@ -532,8 +533,8 @@ class TestServices(TestUtilities, unittest.TestCase):
             )
 
 
-class TestUtils(TestUtilities, unittest.TestCase):
-    """Other tests"""
+class TestLocalUtils(BaseTestUtils, unittest.TestCase):
+    """Tests for local utilities"""
 
     def test_update_version_updates_only_version_file(self):
         repository_root = Path(__file__).resolve().parents[1]

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -126,8 +126,8 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
                 f"body{{--openwisp-test: {cls.custom_static_token};}}"
             )
         script = rf"""
-            grep -q OPENWISP_ADMIN_THEME_LINKS /opt/openwisp/openwisp/settings.py || \
-            printf "\nOPENWISP_ADMIN_THEME_LINKS=[{{\"type\":\"text/css\",\"href\":\"/static/admin/css/openwisp.css\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"text/css\",\"href\":\"/static/{cls.config["custom_css_filename"]}\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"image/x-icon\",\"href\":\"ui/openwisp/images/favicon.png\",\"rel\":\"icon\"}}]\n" >> /opt/openwisp/openwisp/settings.py &&
+            sed -i '/^OPENWISP_ADMIN_THEME_LINKS[[:space:]]*=/d' /opt/openwisp/openwisp/settings.py &&
+            printf "\nOPENWISP_ADMIN_THEME_LINKS=[{{\"type\":\"text/css\",\"href\":\"/static/admin/css/openwisp.css\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"text/css\",\"href\":\"/static/{cls.config["custom_css_filename"]}\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"image/svg+xml\",\"href\":\"ui/openwisp/images/favicon.svg\",\"rel\":\"icon\"}}]\n" >> /opt/openwisp/openwisp/settings.py &&
             python collectstatic.py &&
             uwsgi --reload uwsgi.pid
         """  # noqa: E501

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -12,7 +12,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
-from utils import BaseTestUtils, SeleniumTestUtils
+from utils import BaseTestUtils, FunctionalTestUtils
 
 
 # 0 in the name is on purpose for alphabetical discovery
@@ -61,48 +61,13 @@ class Test0Preconditions(BaseTestUtils, unittest.TestCase):
             self.fail(f"All celery workers are not online: {online_workers}")
 
 
-class TestServices(SeleniumTestUtils, unittest.TestCase):
+class TestServices(FunctionalTestUtils, unittest.TestCase):
     custom_static_token = None
 
     @property
     def failureException(self):
         TestServices.failed_test = True
         return super().failureException
-
-    @classmethod
-    def _execute_docker_compose_command(cls, cmd_args, use_text_mode=False):
-        """Execute a docker compose command and log output.
-
-        Args:
-            cmd_args: List of command arguments for subprocess.Popen
-            use_text_mode: If True, use text mode for subprocess output
-
-        Returns:
-            Tuple of (output, error) from command execution
-        """
-        kwargs = {
-            "stdout": subprocess.PIPE,
-            "stderr": subprocess.PIPE,
-            "cwd": cls.root_location,
-        }
-        if use_text_mode:
-            kwargs["text"] = True
-        cmd = subprocess.run(cmd_args, check=False, **kwargs)
-        if use_text_mode:
-            output, error = cmd.stdout, cmd.stderr
-        else:
-            output = cmd.stdout.decode("utf-8", errors="replace") if cmd.stdout else ""
-            error = cmd.stderr.decode("utf-8", errors="replace") if cmd.stderr else ""
-        output, error = map(str, (cmd.stdout, cmd.stderr))
-        with open(cls.config["logs_file"], "a") as logs_file:
-            logs_file.write(output)
-            logs_file.write(error)
-        if cmd.returncode != 0:
-            raise RuntimeError(
-                f"docker compose command failed "
-                f"({cmd.returncode}): {' '.join(cmd_args)}"
-            )
-        return output, error
 
     @classmethod
     def _setup_admin_theme_links(cls):
@@ -127,7 +92,7 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
             )
         script = rf"""
             sed -i '/^OPENWISP_ADMIN_THEME_LINKS[[:space:]]*=/d' /opt/openwisp/openwisp/settings.py &&
-            printf "\nOPENWISP_ADMIN_THEME_LINKS=[{{\"type\":\"text/css\",\"href\":\"/static/admin/css/openwisp.css\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"text/css\",\"href\":\"/static/{cls.config["custom_css_filename"]}\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"image/svg+xml\",\"href\":\"ui/openwisp/images/favicon.svg\",\"rel\":\"icon\"}}]\n" >> /opt/openwisp/openwisp/settings.py &&
+            printf "\nOPENWISP_ADMIN_THEME_LINKS=[{{\"type\":\"text/css\",\"href\":\"/static/admin/css/openwisp.css\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"text/css\",\"href\":\"/static/{cls.config["custom_css_filename"]}\",\"rel\":\"stylesheet\",\"media\":\"all\"}},{{\"type\":\"image/svg+xml\",\"href\":\"/static/ui/openwisp/images/favicon.svg\",\"rel\":\"icon\"}}]\n" >> /opt/openwisp/openwisp/settings.py &&
             python collectstatic.py &&
             uwsgi --reload uwsgi.pid
         """  # noqa: E501
@@ -154,27 +119,7 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
         avoid any Selenium dependency during setup.
         """
         try:
-            cls._execute_docker_compose_command(
-                [
-                    "docker",
-                    "compose",
-                    "exec",
-                    "-T",
-                    "dashboard",
-                    "python",
-                    "manage.py",
-                    "shell",
-                    "-c",
-                    (
-                        "from openwisp_users.models import User; "
-                        "User.objects.filter("
-                        "username__in=['signup-user', 'test_superuser', "
-                        "'test_superuser2']"
-                        ").delete()"
-                    ),
-                ],
-                use_text_mode=True,
-            )
+            cls.delete_test_users("signup-user", "test_superuser", "test_superuser2")
         except Exception as e:
             exc_type = type(e).__name__
             print(
@@ -224,6 +169,12 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        try:
+            cls.delete_test_users(*cls.test_usernames_to_delete)
+            cls.test_usernames_to_delete.clear()
+        except Exception as e:
+            exc_type = type(e).__name__
+            print(f"Unable to delete test users: {exc_type}: {e}")
         for resource_link in cls.objects_to_delete:
             try:
                 cls._delete_object(resource_link)
@@ -278,6 +229,13 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
     def test_custom_static_files_loaded(self):
         self.login()
         self.open("/admin/")
+        favicon_href = self.web_driver.find_element(
+            By.CSS_SELECTOR, 'link[rel="icon"]'
+        ).get_attribute("href")
+        self.assertRegex(
+            favicon_href,
+            r"/static/ui/openwisp/images/favicon(\.[0-9a-f]+)?\.svg$",
+        )
         # Check if the custom CSS variable is applied
         value = self.web_driver.execute_script(
             "return getComputedStyle(document.body)"
@@ -363,6 +321,7 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
     def test_forgot_password(self):
         """Test forgot password to ensure that postfix is working properly."""
 
+        self.login()
         self.logout()
         try:
             WebDriverWait(self.base_driver, 3).until(
@@ -464,23 +423,22 @@ class TestServices(SeleniumTestUtils, unittest.TestCase):
     def test_radius_user_registration(self):
         """Ensure users can register using the RADIUS API."""
         url = f"{self.config['api_url']}/api/v1/radius/organization/default/account/"
-        response = requests.post(
-            url,
-            json={
-                "username": "signup-user",
-                "email": "user@signup.com",
-                "password1": "rLx6OH%[",
-                "password2": "rLx6OH%[",
-            },
-            verify=False,
-        )
-        self.assertEqual(response.status_code, 201)
-        # Delete the created user
-        self.login()
-        self.get_resource(
-            "signup-user", "/admin/openwisp_users/user/", "field-username"
-        )
-        self.objects_to_delete.append(self.base_driver.current_url)
+        username = "signup-user"
+        try:
+            response = requests.post(
+                url,
+                json={
+                    "username": username,
+                    "email": "user@signup.com",
+                    "password1": "rLx6OH%[",
+                    "password2": "rLx6OH%[",
+                },
+                verify=False,
+                timeout=10,
+            )
+            self.assertEqual(response.status_code, 201, response.text)
+        finally:
+            self.delete_test_users(username)
 
     def test_freeradius(self):
         """Ensure freeradius service is working correctly."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,7 @@ from selenium.webdriver.common.by import By
 class BaseTestUtils:
     """Base class for setting up test parameters and utilities."""
 
+    docker_compose_timeout = 120
     docker_client = docker.from_env()
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
@@ -28,6 +29,52 @@ class BaseTestUtils:
         """Keep verbose unittest output focused on test names, not docstrings."""
         return None
 
+    @classmethod
+    def _execute_docker_compose_command(cls, cmd_args, use_text_mode=False):
+        """Execute a docker compose command and log output."""
+        kwargs = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "cwd": cls.root_location,
+        }
+        if use_text_mode:
+            kwargs["text"] = True
+        try:
+            cmd = subprocess.run(
+                cmd_args,
+                check=False,
+                timeout=cls.docker_compose_timeout,
+                **kwargs,
+            )
+        except subprocess.TimeoutExpired as e:
+            output = e.stdout or ""
+            error = e.stderr or ""
+            if isinstance(output, bytes):
+                output = output.decode("utf-8", errors="replace") if output else ""
+            if isinstance(error, bytes):
+                error = error.decode("utf-8", errors="replace") if error else ""
+            with open(cls.config["logs_file"], "a") as logs_file:
+                logs_file.write(output)
+                logs_file.write(error)
+            raise RuntimeError(
+                "docker compose command timed out "
+                f"after {cls.docker_compose_timeout}s: {' '.join(cmd_args)}"
+            )
+        if use_text_mode:
+            output, error = cmd.stdout, cmd.stderr
+        else:
+            output = cmd.stdout.decode("utf-8", errors="replace") if cmd.stdout else ""
+            error = cmd.stderr.decode("utf-8", errors="replace") if cmd.stderr else ""
+        with open(cls.config["logs_file"], "a") as logs_file:
+            logs_file.write(output)
+            logs_file.write(error)
+        if cmd.returncode != 0:
+            raise RuntimeError(
+                f"docker compose command failed "
+                f"({cmd.returncode}): {' '.join(cmd_args)}"
+            )
+        return output, error
+
     def docker_compose_get_container_id(self, container_name):
         """Get the Docker container ID for a specific container.
 
@@ -38,21 +85,43 @@ class BaseTestUtils:
         Returns:
             str: The ID of the Docker container.
         """
-        services_output = subprocess.Popen(
-            ["docker", "compose", "ps", "--quiet", container_name],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=self.root_location,
+        output, _ = self._execute_docker_compose_command(
+            ["docker", "compose", "ps", "--quiet", container_name]
         )
-        output, _ = services_output.communicate()
-        return output.rstrip().decode("utf-8")
+        return output.rstrip()
 
 
-class SeleniumTestUtils(SeleniumTestMixin, BaseTestUtils):
+class FunctionalTestUtils(SeleniumTestMixin, BaseTestUtils):
     """Utilities for functional testing."""
 
     objects_to_delete = []
+    test_usernames_to_delete = set()
     browser = "chrome"
+
+    @classmethod
+    def delete_test_users(cls, *usernames):
+        """Delete test-created users without relying on browser state."""
+        usernames = sorted(set(usernames))
+        if not usernames:
+            return
+        cls._execute_docker_compose_command(
+            [
+                "docker",
+                "compose",
+                "exec",
+                "-T",
+                "dashboard",
+                "python",
+                "manage.py",
+                "shell",
+                "-c",
+                (
+                    "from openwisp_users.models import User; "
+                    f"User.objects.filter(username__in={usernames!r}).delete()"
+                ),
+            ],
+            use_text_mode=True,
+        )
 
     def setUp(self):
         # Override TestSeleniumMixin setUp which uses
@@ -130,7 +199,7 @@ class SeleniumTestUtils(SeleniumTestMixin, BaseTestUtils):
         self.find_element(By.NAME, "password2", driver=driver).send_keys(password)
         self.find_element(By.NAME, "is_superuser", driver=driver).click()
         self._click_save_btn(driver)
-        self.objects_to_delete.append(driver.current_url)
+        self.test_usernames_to_delete.add(username)
         self._click_save_btn(driver)
         self._wait_until_page_ready()
         self.wait_for_visibility(By.ID, "content", driver=driver, timeout=10)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,12 +11,8 @@ from selenium.common.exceptions import NoAlertPresentException
 from selenium.webdriver.common.by import By
 
 
-class TestConfig:
-    """Configuration class for setting up test parameters and utilities."""
-
-    def shortDescription(self):
-        """Return a short description for the test."""
-        return None
+class BaseTestUtils:
+    """Base class for setting up test parameters and utilities."""
 
     docker_client = docker.from_env()
     ctx = ssl.create_default_context()
@@ -28,9 +24,32 @@ class TestConfig:
     with open(config_file) as json_file:
         config = json.load(json_file)
 
+    def shortDescription(self):
+        """Keep verbose unittest output focused on test names, not docstrings."""
+        return None
 
-class TestUtilities(SeleniumTestMixin, TestConfig):
-    """Utility functions for testing."""
+    def docker_compose_get_container_id(self, container_name):
+        """Get the Docker container ID for a specific container.
+
+        Parameters:
+
+        - container_name (str): The name of the Docker container.
+
+        Returns:
+            str: The ID of the Docker container.
+        """
+        services_output = subprocess.Popen(
+            ["docker", "compose", "ps", "--quiet", container_name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.root_location,
+        )
+        output, _ = services_output.communicate()
+        return output.rstrip().decode("utf-8")
+
+
+class SeleniumTestUtils(SeleniumTestMixin, BaseTestUtils):
+    """Utilities for functional testing."""
 
     objects_to_delete = []
     browser = "chrome"
@@ -253,25 +272,6 @@ class TestUtilities(SeleniumTestMixin, TestConfig):
         self._ignore_location_alert(driver)
         self._click_save_btn(driver)
         self.get_resource(location_name, "/admin/geo/location/", driver=driver)
-
-    def docker_compose_get_container_id(self, container_name):
-        """Get the Docker container ID for a specific container.
-
-        Parameters:
-
-        - container_name (str): The name of the Docker container.
-
-        Returns:
-            str: The ID of the Docker container.
-        """
-        services_output = subprocess.Popen(
-            ["docker", "compose", "ps", "--quiet", container_name],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=self.root_location,
-        )
-        output, _ = services_output.communicate()
-        return output.rstrip().decode("utf-8")
 
     def create_network_topology(
         self,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

This pull request fixes docker-openwisp functional test failures exposed by recent changes in [`openwisp-utils`](https://github.com/openwisp/openwisp-utils) and by pre-existing test isolation issues in the Selenium suite.

## Problems Solved

**Non-Selenium tests inherited Selenium setup**

[`openwisp-utils`](https://github.com/openwisp/openwisp-utils) recently changed `SeleniumTestMixin.setUpClass()` so it accesses Django settings while preparing Selenium database connection handling.

In docker-openwisp, `Pretest` and `TestUtils` were not Selenium tests, but they inherited `SeleniumTestMixin` indirectly through the shared `TestUtilities` class. These tests run outside a configured `DJANGO_SETTINGS_MODULE`, so the full suite failed with:

```text
django.core.exceptions.ImproperlyConfigured: Requested setting DATABASES, but settings are not configured.
```

The test utilities are now split into `BaseTestUtils` and `FunctionalTestUtils`, so non-Selenium tests do not run Selenium class setup.

**The custom theme setup injected a stale favicon path**

[`openwisp-utils`](https://github.com/openwisp/openwisp-utils) changed the admin favicon from `favicon.png` to `favicon.svg`.

The docker-openwisp functional test setup was still injecting this value through `OPENWISP_ADMIN_THEME_LINKS`:

```text
ui/openwisp/images/favicon.png
```

Because that path is relative, the browser resolved it below `/admin/`, producing requests like:

```text
/admin/ui/openwisp/images/favicon.png
```

That produced a `404` browser console error and made `test_console_errors` fail.

The setup now injects the SVG favicon with the correct MIME type:

```text
image/svg+xml
```

It also replaces any existing `OPENWISP_ADMIN_THEME_LINKS` assignment before appending the test value, so retry runs do not keep stale favicon settings.

**Functional tests depended on shared browser state**

Some tests created users through the admin UI or through the RADIUS API, then cleaned them up later through Selenium. That cleanup depended on the browser still being logged in, which could fail after tests that intentionally logged out.

Test-created users are now removed through the Django ORM with `manage.py shell`, avoiding browser-state-dependent cleanup. This makes `test_radius_user_registration` independent from the rest of `TestServices`.

**The password reset test depended on previous login state**

`test_forgot_password` previously assumed another test had already logged the browser in. It now logs in explicitly before testing logout and password reset behavior.

**Verbose unittest output was noisy**

The shared base test utility now keeps verbose unittest output focused on test names instead of method docstrings.

## Reference to Existing Issue

Not needed. This fixes CI failures in the test suite.