### PR TITLE
[feature] Configured Nginx to serve precompressed static files #560

### DIFF
--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -951,6 +951,14 @@ Nginx
   application/x-font-ttf font/opentype``.
 - **Default:** ``\*``.
 
+``NGINX_BROTLI_SWITCH``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Explanation:** Enables or disables serving precompressed Brotli files
+  from the static files directory.
+- **Valid Values:** ``on``, ``off``.
+- **Default:** ``on``.
+
 ``NGINX_HTTPS_ALLOWED_IPS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -987,6 +987,14 @@ Nginx
   application/x-font-ttf font/opentype``.
 - **Default:** ``\*``.
 
+``NGINX_BROTLI_SWITCH``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Explanation:** Enables or disables serving precompressed Brotli files
+  from the static files directory.
+- **Valid Values:** ``on``, ``off``.
+- **Default:** ``on``.
+
 ``NGINX_HTTPS_ALLOWED_IPS``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/images/openwisp_dashboard/module_settings.py
+++ b/images/openwisp_dashboard/module_settings.py
@@ -85,10 +85,6 @@ STORAGES = {
         "BACKEND": "openwisp_utils.storage.CompressStaticFilesStorage",
     },
 }
-BROTLI_STATIC_COMPRESSION = False
-# pregenerate static gzip files to save CPU
-GZIP_STATIC_COMPRESSION = True
-
 HTTP_SCHEME = request_scheme()
 HTTP_PORT = (
     os.getenv("NGINX_SSL_PORT", "443")

--- a/images/openwisp_dashboard/module_settings.py
+++ b/images/openwisp_dashboard/module_settings.py
@@ -82,9 +82,18 @@ STORAGES = {
         "BACKEND": "openwisp_utils.storage.CompressStaticFilesStorage",
     },
 }
-BROTLI_STATIC_COMPRESSION = False
-# pregenerate static gzip files to save CPU
-GZIP_STATIC_COMPRESSION = True
+HTTP_SCHEME = request_scheme()
+HTTP_PORT = (
+    os.getenv("NGINX_SSL_PORT", "443")
+    if HTTP_SCHEME == "https"
+    else os.getenv("NGINX_PORT", "80")
+)
+HTTP_PORT = (
+    ""
+    if HTTP_SCHEME == "https" and os.environ["SSL_CERT_MODE"].lower() == "external"
+    else f":{HTTP_PORT}"
+)
+API_BASEURL = f'{HTTP_SCHEME}://{os.environ["API_DOMAIN"]}{HTTP_PORT}'
 
 OPENWISP_NETWORK_TOPOLOGY_API_URLCONF = "openwisp_network_topology.urls"
 OPENWISP_MONITORING_API_URLCONF = "openwisp_monitoring.urls"

--- a/images/openwisp_dashboard/module_settings.py
+++ b/images/openwisp_dashboard/module_settings.py
@@ -82,18 +82,6 @@ STORAGES = {
         "BACKEND": "openwisp_utils.storage.CompressStaticFilesStorage",
     },
 }
-HTTP_SCHEME = request_scheme()
-HTTP_PORT = (
-    os.getenv("NGINX_SSL_PORT", "443")
-    if HTTP_SCHEME == "https"
-    else os.getenv("NGINX_PORT", "80")
-)
-HTTP_PORT = (
-    ""
-    if HTTP_SCHEME == "https" and os.environ["SSL_CERT_MODE"].lower() == "external"
-    else f":{HTTP_PORT}"
-)
-API_BASEURL = f'{HTTP_SCHEME}://{os.environ["API_DOMAIN"]}{HTTP_PORT}'
 
 OPENWISP_NETWORK_TOPOLOGY_API_URLCONF = "openwisp_network_topology.urls"
 OPENWISP_MONITORING_API_URLCONF = "openwisp_monitoring.urls"

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,7 +1,46 @@
-FROM nginx:1.31.2-alpine
+ARG NGINX_VERSION=1.31.2
+
+# Build the nginx brotli module against nginx.org's nginx package used by this image.
+# Alpine's nginx module packages target Alpine's own nginx build.
+FROM nginx:${NGINX_VERSION}-alpine AS brotli-builder
+
+ARG NGINX_VERSION
+ARG NGX_BROTLI_VERSION=v1.0.0rc
+
+# hadolint ignore=DL3003,DL3018
+RUN apk add --update --no-cache \
+            brotli-dev \
+            build-base \
+            git \
+            linux-headers \
+            openssl-dev \
+            pcre2-dev \
+            zlib-dev && \
+    git clone --depth 1 --branch ${NGX_BROTLI_VERSION} --recurse-submodules \
+            https://github.com/google/ngx_brotli.git /tmp/ngx_brotli && \
+    wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+            -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \
+    tar xzf /tmp/nginx-${NGINX_VERSION}.tar.gz -C /tmp && \
+    cd /tmp/nginx-${NGINX_VERSION} && \
+    ./configure \
+            --with-compat \
+            --with-cc-opt='-Wno-error=unterminated-string-initialization -Wno-error=vla-parameter' \
+            --add-dynamic-module=/tmp/ngx_brotli && \
+    make modules
+
+FROM nginx:${NGINX_VERSION}-alpine
+
+ARG NGINX_VERSION
+
+RUN mkdir -p /etc/nginx/modules
+
+COPY --from=brotli-builder \
+    /tmp/nginx-${NGINX_VERSION}/objs/ngx_http_brotli_static_module.so \
+    /etc/nginx/modules/ngx_http_brotli_static_module.so
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache \
+            brotli-libs \
             py3-pip \
             certbot \
             certbot-nginx \
@@ -41,6 +80,7 @@ ENV MODULE_NAME=nginx \
     NGINX_GZIP_PROXIED=any \
     NGINX_GZIP_MIN_LENGTH=1000 \
     NGINX_GZIP_TYPES='text/plain image/svg+xml application/json application/javascript text/xml text/css application/xml application/x-font-ttf font/opentype' \
+    NGINX_BROTLI_SWITCH=on \
     NGINX_CUSTOM_FILE=False \
     NGINX_WORKER_PROCESSES=1 \
     NGINX_WORKER_CONNECTIONS=1024 \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,7 +1,46 @@
-FROM nginx:1.31.4-alpine
+ARG NGINX_VERSION=1.31.4
+
+# Build the nginx brotli module against nginx.org's nginx package used by this image.
+# Alpine's nginx module packages target Alpine's own nginx build.
+FROM nginx:${NGINX_VERSION}-alpine AS brotli-builder
+
+ARG NGINX_VERSION
+ARG NGX_BROTLI_VERSION=v1.0.0rc
+
+# hadolint ignore=DL3003,DL3018
+RUN apk add --update --no-cache \
+            brotli-dev \
+            build-base \
+            git \
+            linux-headers \
+            openssl-dev \
+            pcre2-dev \
+            zlib-dev && \
+    git clone --depth 1 --branch ${NGX_BROTLI_VERSION} --recurse-submodules \
+            https://github.com/google/ngx_brotli.git /tmp/ngx_brotli && \
+    wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
+            -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \
+    tar xzf /tmp/nginx-${NGINX_VERSION}.tar.gz -C /tmp && \
+    cd /tmp/nginx-${NGINX_VERSION} && \
+    ./configure \
+            --with-compat \
+            --with-cc-opt='-Wno-error=unterminated-string-initialization -Wno-error=vla-parameter' \
+            --add-dynamic-module=/tmp/ngx_brotli && \
+    make modules
+
+FROM nginx:${NGINX_VERSION}-alpine
+
+ARG NGINX_VERSION
+
+RUN mkdir -p /etc/nginx/modules
+
+COPY --from=brotli-builder \
+    /tmp/nginx-${NGINX_VERSION}/objs/ngx_http_brotli_static_module.so \
+    /etc/nginx/modules/ngx_http_brotli_static_module.so
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache \
+            brotli-libs \
             py3-pip \
             certbot \
             certbot-nginx \
@@ -40,6 +79,7 @@ ENV MODULE_NAME=nginx \
     NGINX_GZIP_PROXIED=any \
     NGINX_GZIP_MIN_LENGTH=1000 \
     NGINX_GZIP_TYPES='text/plain image/svg+xml application/json application/javascript text/xml text/css application/xml application/x-font-ttf font/opentype' \
+    NGINX_BROTLI_SWITCH=on \
     NGINX_CUSTOM_FILE=False \
     NGINX_WORKER_PROCESSES=1 \
     NGINX_WORKER_CONNECTIONS=1024 \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,11 +1,13 @@
 ARG NGINX_VERSION=1.31.4
+ARG NGINX_TARBALL_SHA256=e6f20b644a17a643f059ae6467a1971fe2811587d025e071068753a1f1e3b3c3
 
 # Build the nginx brotli module against nginx.org's nginx package used by this image.
 # Alpine's nginx module packages target Alpine's own nginx build.
 FROM nginx:${NGINX_VERSION}-alpine AS brotli-builder
 
 ARG NGINX_VERSION
-ARG NGX_BROTLI_VERSION=v1.0.0rc
+ARG NGX_BROTLI_COMMIT=25f86f0bac1101b6512135eac5f93c49c63609e3
+ARG NGINX_TARBALL_SHA256
 
 # hadolint ignore=DL3003,DL3018
 RUN apk add --update --no-cache \
@@ -16,10 +18,17 @@ RUN apk add --update --no-cache \
             openssl-dev \
             pcre2-dev \
             zlib-dev && \
-    git clone --depth 1 --branch ${NGX_BROTLI_VERSION} --recurse-submodules \
-            https://github.com/google/ngx_brotli.git /tmp/ngx_brotli && \
+    git init /tmp/ngx_brotli && \
+    git -C /tmp/ngx_brotli remote add origin https://github.com/google/ngx_brotli.git && \
+    git -C /tmp/ngx_brotli fetch --depth 1 origin ${NGX_BROTLI_COMMIT} && \
+    git -C /tmp/ngx_brotli checkout --detach FETCH_HEAD && \
+    git -C /tmp/ngx_brotli submodule update --init --recursive --depth 1 && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
             -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \
+    printf '%s  %s\n' "${NGINX_TARBALL_SHA256}" \
+            "/tmp/nginx-${NGINX_VERSION}.tar.gz" \
+            > /tmp/nginx-${NGINX_VERSION}.sha256 && \
+    sha256sum -c /tmp/nginx-${NGINX_VERSION}.sha256 && \
     tar xzf /tmp/nginx-${NGINX_VERSION}.tar.gz -C /tmp && \
     cd /tmp/nginx-${NGINX_VERSION} && \
     ./configure \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -1,5 +1,4 @@
 ARG NGINX_VERSION=1.31.4
-ARG NGINX_TARBALL_SHA256=e6f20b644a17a643f059ae6467a1971fe2811587d025e071068753a1f1e3b3c3
 
 # Build the nginx brotli module against nginx.org's nginx package used by this image.
 # Alpine's nginx module packages target Alpine's own nginx build.
@@ -7,13 +6,14 @@ FROM nginx:${NGINX_VERSION}-alpine AS brotli-builder
 
 ARG NGINX_VERSION
 ARG NGX_BROTLI_COMMIT=25f86f0bac1101b6512135eac5f93c49c63609e3
-ARG NGINX_TARBALL_SHA256
+ARG NGINX_SIGNING_KEY_FINGERPRINT=D6786CE303D9A9022998DC6CC8464D549AF75C0A
 
 # hadolint ignore=DL3003,DL3018
 RUN apk add --update --no-cache \
             brotli-dev \
             build-base \
             git \
+            gnupg \
             linux-headers \
             openssl-dev \
             pcre2-dev \
@@ -23,12 +23,20 @@ RUN apk add --update --no-cache \
     git -C /tmp/ngx_brotli fetch --depth 1 origin ${NGX_BROTLI_COMMIT} && \
     git -C /tmp/ngx_brotli checkout --detach FETCH_HEAD && \
     git -C /tmp/ngx_brotli submodule update --init --recursive --depth 1 && \
+    wget -q https://nginx.org/keys/pluknet.key -O /tmp/nginx_signing.key && \
+    gpg --batch --show-keys --with-colons /tmp/nginx_signing.key \
+            > /tmp/nginx_signing_key_details && \
+    grep -Fqx "fpr:::::::::${NGINX_SIGNING_KEY_FINGERPRINT}:" \
+            /tmp/nginx_signing_key_details && \
+    mkdir -m 0700 /tmp/gnupg && \
+    GNUPGHOME=/tmp/gnupg gpg --batch --import /tmp/nginx_signing.key && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
             -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \
-    printf '%s  %s\n' "${NGINX_TARBALL_SHA256}" \
-            "/tmp/nginx-${NGINX_VERSION}.tar.gz" \
-            > /tmp/nginx-${NGINX_VERSION}.sha256 && \
-    sha256sum -c /tmp/nginx-${NGINX_VERSION}.sha256 && \
+    wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc \
+            -O /tmp/nginx-${NGINX_VERSION}.tar.gz.asc && \
+    GNUPGHOME=/tmp/gnupg gpg --batch --verify \
+            /tmp/nginx-${NGINX_VERSION}.tar.gz.asc \
+            /tmp/nginx-${NGINX_VERSION}.tar.gz && \
     tar xzf /tmp/nginx-${NGINX_VERSION}.tar.gz -C /tmp && \
     cd /tmp/nginx-${NGINX_VERSION} && \
     ./configure \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -6,7 +6,10 @@ FROM nginx:${NGINX_VERSION}-alpine AS brotli-builder
 
 ARG NGINX_VERSION
 ARG NGX_BROTLI_COMMIT=25f86f0bac1101b6512135eac5f93c49c63609e3
-ARG NGINX_SIGNING_KEY_FINGERPRINT=D6786CE303D9A9022998DC6CC8464D549AF75C0A
+ARG NGINX_ARUT_SIGNING_KEY_FINGERPRINT=43387825DDB1BB97EC36BA5D007C8D7C15D87369
+ARG NGINX_PLUKNET_SIGNING_KEY_FINGERPRINT=D6786CE303D9A9022998DC6CC8464D549AF75C0A
+ARG NGINX_SB_SIGNING_KEY_FINGERPRINT=7338973069ED3F443F4D37DFA64FD5B17ADB39A8
+ARG NGINX_THRESH_SIGNING_KEY_FINGERPRINT=13C82A63B603576156E30A4EA0EA981B66B0D967
 
 # hadolint ignore=DL3003,DL3018
 RUN apk add --update --no-cache \
@@ -23,13 +26,26 @@ RUN apk add --update --no-cache \
     git -C /tmp/ngx_brotli fetch --depth 1 origin ${NGX_BROTLI_COMMIT} && \
     git -C /tmp/ngx_brotli checkout --detach FETCH_HEAD && \
     git -C /tmp/ngx_brotli submodule update --init --recursive --depth 1 && \
-    wget -q https://nginx.org/keys/pluknet.key -O /tmp/nginx_signing.key && \
-    gpg --batch --show-keys --with-colons /tmp/nginx_signing.key \
+    mkdir -m 0700 /tmp/gnupg /tmp/nginx_signing_keys && \
+    wget -q https://nginx.org/keys/arut.key \
+            -O /tmp/nginx_signing_keys/arut.key && \
+    wget -q https://nginx.org/keys/pluknet.key \
+            -O /tmp/nginx_signing_keys/pluknet.key && \
+    wget -q https://nginx.org/keys/sb.key \
+            -O /tmp/nginx_signing_keys/sb.key && \
+    wget -q https://nginx.org/keys/thresh.key \
+            -O /tmp/nginx_signing_keys/thresh.key && \
+    GNUPGHOME=/tmp/gnupg gpg --batch --show-keys --with-colons \
+            /tmp/nginx_signing_keys/*.key \
             > /tmp/nginx_signing_key_details && \
-    grep -Fqx "fpr:::::::::${NGINX_SIGNING_KEY_FINGERPRINT}:" \
-            /tmp/nginx_signing_key_details && \
-    mkdir -m 0700 /tmp/gnupg && \
-    GNUPGHOME=/tmp/gnupg gpg --batch --import /tmp/nginx_signing.key && \
+    for fingerprint in \
+            ${NGINX_ARUT_SIGNING_KEY_FINGERPRINT} \
+            ${NGINX_PLUKNET_SIGNING_KEY_FINGERPRINT} \
+            ${NGINX_SB_SIGNING_KEY_FINGERPRINT} \
+            ${NGINX_THRESH_SIGNING_KEY_FINGERPRINT}; do \
+        grep -Fqx "fpr:::::::::${fingerprint}:" /tmp/nginx_signing_key_details; \
+    done && \
+    GNUPGHOME=/tmp/gnupg gpg --batch --import /tmp/nginx_signing_keys/*.key && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
             -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz.asc \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -45,6 +45,22 @@ RUN apk add --update --no-cache \
             ${NGINX_THRESH_SIGNING_KEY_FINGERPRINT}; do \
         grep -Fqx "fpr:::::::::${fingerprint}:" /tmp/nginx_signing_key_details || exit 1; \
     done && \
+    printf '%s\n' \
+            "${NGINX_ARUT_SIGNING_KEY_FINGERPRINT}" \
+            "${NGINX_PLUKNET_SIGNING_KEY_FINGERPRINT}" \
+            "${NGINX_SB_SIGNING_KEY_FINGERPRINT}" \
+            "${NGINX_THRESH_SIGNING_KEY_FINGERPRINT}" \
+            > /tmp/nginx_expected_fingerprints && \
+    sort -u /tmp/nginx_expected_fingerprints \
+            > /tmp/nginx_expected_primary_fingerprints && \
+    awk -F: '\
+        $1 == "pub" { primary = 1; next } \
+        primary && $1 == "fpr" { print $10; primary = 0 } \
+    ' /tmp/nginx_signing_key_details > /tmp/nginx_actual_fingerprints && \
+    sort -u /tmp/nginx_actual_fingerprints \
+            > /tmp/nginx_actual_primary_fingerprints && \
+    cmp -s /tmp/nginx_actual_primary_fingerprints \
+            /tmp/nginx_expected_primary_fingerprints && \
     GNUPGHOME=/tmp/gnupg gpg --batch --import /tmp/nginx_signing_keys/*.key && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \
             -O /tmp/nginx-${NGINX_VERSION}.tar.gz && \

--- a/images/openwisp_nginx/Dockerfile
+++ b/images/openwisp_nginx/Dockerfile
@@ -43,7 +43,7 @@ RUN apk add --update --no-cache \
             ${NGINX_PLUKNET_SIGNING_KEY_FINGERPRINT} \
             ${NGINX_SB_SIGNING_KEY_FINGERPRINT} \
             ${NGINX_THRESH_SIGNING_KEY_FINGERPRINT}; do \
-        grep -Fqx "fpr:::::::::${fingerprint}:" /tmp/nginx_signing_key_details; \
+        grep -Fqx "fpr:::::::::${fingerprint}:" /tmp/nginx_signing_key_details || exit 1; \
     done && \
     GNUPGHOME=/tmp/gnupg gpg --batch --import /tmp/nginx_signing_keys/*.key && \
     wget -q https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz \

--- a/images/openwisp_nginx/nginx.template.conf
+++ b/images/openwisp_nginx/nginx.template.conf
@@ -3,6 +3,8 @@
 # Changes in given http block reflect in
 # all openwisp server blocks.
 
+load_module modules/ngx_http_brotli_static_module.so;
+
 user  nginx;
 worker_processes  ${NGINX_WORKER_PROCESSES};
 worker_rlimit_nofile  ${NGINX_WORKER_RLIMIT_NOFILE};

--- a/images/openwisp_nginx/openwisp.ssl.template.conf
+++ b/images/openwisp_nginx/openwisp.ssl.template.conf
@@ -60,10 +60,15 @@ server {
         allow $NGINX_ADMIN_ALLOW_NETWORK;
         deny all;
     }
-    location /static/ {
+    location /static/custom/ {
+        alias /opt/openwisp/public/custom/static/custom/;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
-        try_files /custom${DOLLAR}uri /${DOLLAR}uri;
+    }
+    location /static/ {
+        alias /opt/openwisp/public/static/;
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
     }
     location / {
         try_files /custom/maintenance.html ${DOLLAR}uri ${DOLLAR}uri/index.html @uwsgi;

--- a/images/openwisp_nginx/openwisp.ssl.template.conf
+++ b/images/openwisp_nginx/openwisp.ssl.template.conf
@@ -27,7 +27,6 @@ server {
 
     # GZIP Configurations
     gzip ${NGINX_GZIP_SWITCH};
-    gzip_static ${NGINX_GZIP_SWITCH};
     gzip_comp_level ${NGINX_GZIP_LEVEL};
     gzip_proxied ${NGINX_GZIP_PROXIED};
     gzip_min_length ${NGINX_GZIP_MIN_LENGTH};
@@ -62,6 +61,8 @@ server {
         deny all;
     }
     location /static/ {
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
         try_files /custom${DOLLAR}uri /${DOLLAR}uri;
     }
     location / {

--- a/images/openwisp_nginx/openwisp.ssl.template.conf
+++ b/images/openwisp_nginx/openwisp.ssl.template.conf
@@ -22,7 +22,6 @@ server {
 
     # GZIP Configurations
     gzip ${NGINX_GZIP_SWITCH};
-    gzip_static ${NGINX_GZIP_SWITCH};
     gzip_comp_level ${NGINX_GZIP_LEVEL};
     gzip_proxied ${NGINX_GZIP_PROXIED};
     gzip_min_length ${NGINX_GZIP_MIN_LENGTH};
@@ -57,6 +56,8 @@ server {
         deny all;
     }
     location /static/ {
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
         try_files /custom${DOLLAR}uri /${DOLLAR}uri;
     }
     location / {

--- a/images/openwisp_nginx/openwisp.ssl.template.conf
+++ b/images/openwisp_nginx/openwisp.ssl.template.conf
@@ -55,10 +55,15 @@ server {
         allow $NGINX_ADMIN_ALLOW_NETWORK;
         deny all;
     }
-    location /static/ {
+    location /static/custom/ {
+        alias /opt/openwisp/public/custom/static/custom/;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
-        try_files /custom${DOLLAR}uri /${DOLLAR}uri;
+    }
+    location /static/ {
+        alias /opt/openwisp/public/static/;
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
     }
     location / {
         try_files /custom/maintenance.html ${DOLLAR}uri ${DOLLAR}uri/index.html @uwsgi;

--- a/images/openwisp_nginx/openwisp.ssl.template.conf
+++ b/images/openwisp_nginx/openwisp.ssl.template.conf
@@ -55,13 +55,14 @@ server {
         allow $NGINX_ADMIN_ALLOW_NETWORK;
         deny all;
     }
-    location /static/custom/ {
-        alias /opt/openwisp/public/custom/static/custom/;
+    location /static/ {
+        root /opt/openwisp/public/custom;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
+        error_page 404 = @static;
     }
-    location /static/ {
-        alias /opt/openwisp/public/static/;
+    location @static {
+        root /opt/openwisp/public;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
     }

--- a/images/openwisp_nginx/openwisp.template.conf
+++ b/images/openwisp_nginx/openwisp.template.conf
@@ -34,6 +34,8 @@ server {
         proxy_set_header Connection "upgrade";
     }
     location /static/ {
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
         try_files /custom${DOLLAR}uri /${DOLLAR}uri;
     }
     location / {

--- a/images/openwisp_nginx/openwisp.template.conf
+++ b/images/openwisp_nginx/openwisp.template.conf
@@ -33,10 +33,15 @@ server {
         proxy_set_header Upgrade ${DOLLAR}http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-    location /static/ {
+    location /static/custom/ {
+        alias /opt/openwisp/public/custom/static/custom/;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
-        try_files /custom${DOLLAR}uri /${DOLLAR}uri;
+    }
+    location /static/ {
+        alias /opt/openwisp/public/static/;
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
     }
     location / {
         error_page 403 = @deny;

--- a/images/openwisp_nginx/openwisp.template.conf
+++ b/images/openwisp_nginx/openwisp.template.conf
@@ -33,6 +33,8 @@ server {
         proxy_set_header Connection "upgrade";
     }
     location /static/ {
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
         try_files /custom${DOLLAR}uri /${DOLLAR}uri;
     }
     location / {

--- a/images/openwisp_nginx/openwisp.template.conf
+++ b/images/openwisp_nginx/openwisp.template.conf
@@ -32,13 +32,14 @@ server {
         proxy_set_header Upgrade ${DOLLAR}http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-    location /static/custom/ {
-        alias /opt/openwisp/public/custom/static/custom/;
+    location /static/ {
+        root /opt/openwisp/public/custom;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
+        error_page 404 = @static;
     }
-    location /static/ {
-        alias /opt/openwisp/public/static/;
+    location @static {
+        root /opt/openwisp/public;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
     }

--- a/images/openwisp_nginx/openwisp.template.conf
+++ b/images/openwisp_nginx/openwisp.template.conf
@@ -32,10 +32,15 @@ server {
         proxy_set_header Upgrade ${DOLLAR}http_upgrade;
         proxy_set_header Connection "upgrade";
     }
-    location /static/ {
+    location /static/custom/ {
+        alias /opt/openwisp/public/custom/static/custom/;
         gzip_static ${NGINX_GZIP_SWITCH};
         brotli_static ${NGINX_BROTLI_SWITCH};
-        try_files /custom${DOLLAR}uri /${DOLLAR}uri;
+    }
+    location /static/ {
+        alias /opt/openwisp/public/static/;
+        gzip_static ${NGINX_GZIP_SWITCH};
+        brotli_static ${NGINX_BROTLI_SWITCH};
     }
     location / {
         error_page 403 = @deny;

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -217,8 +217,11 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             Path(cls.root_location)
             / "customization"
             / "theme"
+            / "custom"
             / cls.config["custom_css_filename"]
         )
+        cls.custom_css_directory_existed = cls.custom_css_path.parent.exists()
+        cls.custom_css_path.parent.mkdir(parents=True, exist_ok=True)
         cls.custom_css_path.write_text(
             f"body{{--openwisp-test: {cls.custom_static_token};}}"
         )
@@ -231,7 +234,7 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             },
             {
                 "type": "text/css",
-                "href": f"/static/{cls.config['custom_css_filename']}",
+                "href": f"/static/custom/{cls.config['custom_css_filename']}",
                 "rel": "stylesheet",
                 "media": "all",
             },
@@ -266,6 +269,8 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
         else:
             cls.custom_settings_path.unlink(missing_ok=True)
         cls.custom_css_path.unlink(missing_ok=True)
+        if not cls.custom_css_directory_existed:
+            cls.custom_css_path.parent.rmdir()
         cls._execute_docker_compose_command(
             ["docker", "compose", "up", "--detach", "--force-recreate", "dashboard"]
         )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1062,6 +1062,7 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
     """Tests for local utilities"""
 
     def test_nginx_source_verification_tracks_version(self):
+        """Ensure Dependabot Nginx bumps retain source authentication."""
         dockerfile = (
             Path(self.root_location) / "images" / "openwisp_nginx" / "Dockerfile"
         ).read_text()
@@ -1070,6 +1071,7 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
         self.assertIn("gpg --batch --verify", dockerfile)
 
     def test_admin_theme_cleanup_restores_existing_css(self):
+        """Ensure theme setup does not remove a pre-existing custom CSS file."""
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             css_path = (

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -6,6 +6,7 @@ import time
 import unittest
 from contextlib import contextmanager
 from pathlib import Path
+from unittest import mock
 from urllib import error as urlerror
 from urllib import request
 from urllib.parse import urlsplit, urlunsplit
@@ -221,6 +222,9 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             / cls.config["custom_css_filename"]
         )
         cls.custom_css_directory_existed = cls.custom_css_path.parent.exists()
+        cls.custom_css_existed = cls.custom_css_path.exists()
+        if cls.custom_css_existed:
+            cls.custom_css = cls.custom_css_path.read_bytes()
         cls.custom_css_path.parent.mkdir(parents=True, exist_ok=True)
         cls.custom_css_path.write_text(
             f"body{{--openwisp-test: {cls.custom_static_token};}}"
@@ -268,7 +272,10 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             cls.custom_settings_path.write_text(cls.custom_settings)
         else:
             cls.custom_settings_path.unlink(missing_ok=True)
-        cls.custom_css_path.unlink(missing_ok=True)
+        if cls.custom_css_existed:
+            cls.custom_css_path.write_bytes(cls.custom_css)
+        else:
+            cls.custom_css_path.unlink(missing_ok=True)
         if not cls.custom_css_directory_existed:
             cls.custom_css_path.parent.rmdir()
         cls._execute_docker_compose_command(
@@ -491,22 +498,24 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
         }
         custom_nginx_directory_existed = custom_nginx_directory.exists()
         custom_static_directory_existed = custom_static_directory.exists()
-        self._execute_docker_compose_command(
-            [
-                "docker",
-                "compose",
-                "run",
-                "--rm",
-                "--no-deps",
-                "--volume",
-                f"{script}:/test_precompress_static.py:ro",
-                "--entrypoint",
-                "python",
-                "dashboard",
-                "/test_precompress_static.py",
-            ]
-        )
         try:
+            for file_path in custom_files:
+                file_path.unlink(missing_ok=True)
+            self._execute_docker_compose_command(
+                [
+                    "docker",
+                    "compose",
+                    "run",
+                    "--rm",
+                    "--no-deps",
+                    "--volume",
+                    f"{script}:/test_precompress_static.py:ro",
+                    "--entrypoint",
+                    "python",
+                    "dashboard",
+                    "/test_precompress_static.py",
+                ]
+            )
             app_url = urlsplit(self.live_server_url)
             static_url = urlunsplit(
                 ("https", app_url.netloc, "/static/precompressed-static.txt", "", "")
@@ -1051,6 +1060,52 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
 
 class TestLocalUtils(BaseTestUtils, unittest.TestCase):
     """Tests for local utilities"""
+
+    def test_nginx_source_verification_tracks_version(self):
+        dockerfile = (
+            Path(self.root_location) / "images" / "openwisp_nginx" / "Dockerfile"
+        ).read_text()
+        self.assertNotIn("NGINX_TARBALL_SHA256", dockerfile)
+        self.assertIn("nginx-${NGINX_VERSION}.tar.gz.asc", dockerfile)
+        self.assertIn("gpg --batch --verify", dockerfile)
+
+    def test_admin_theme_cleanup_restores_existing_css(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            css_path = (
+                root / "customization" / "theme" / "custom" / "custom-openwisp-test.css"
+            )
+            css_path.parent.mkdir(parents=True)
+            original_css = b"/* existing custom theme */\n"
+            css_path.write_bytes(original_css)
+
+            class CleanupTestServices(TestServices):
+                pass
+
+            CleanupTestServices.custom_settings_path = root / "settings.py"
+            CleanupTestServices.custom_settings_path.write_text("")
+            CleanupTestServices.root_location = root
+            CleanupTestServices.config = {
+                "app_url": "https://dashboard.openwisp.org",
+                "custom_css_filename": css_path.name,
+                "services_delay_retries": 0,
+                "services_max_retries": 1,
+            }
+            with mock.patch.object(
+                CleanupTestServices, "addClassCleanup"
+            ), mock.patch.object(
+                CleanupTestServices, "reverse_url", return_value="/admin/login/"
+            ), mock.patch.object(
+                CleanupTestServices,
+                "_execute_docker_compose_command",
+                return_value=("", ""),
+            ), mock.patch.object(
+                request, "urlopen", return_value=mock.Mock()
+            ):
+                CleanupTestServices._setup_admin_theme_links()
+                self.assertNotEqual(css_path.read_bytes(), original_css)
+                CleanupTestServices._cleanup_admin_theme_links()
+            self.assertEqual(css_path.read_bytes(), original_css)
 
     def test_profile_configures_shell_defaults_and_preserves_overrides(self):
         for dev_mode, settings, expected in (

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -480,31 +480,36 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             ]
         )
         try:
-            for encoding, extension in (("br", "br"), ("gzip", "gz")):
-                with self.subTest(encoding=encoding):
-                    request_info = request.Request(
-                        f"{self.live_server_url}/static/precompressed-static.txt",
-                        headers={"Accept-Encoding": encoding},
-                    )
-                    with request.urlopen(
-                        request_info, context=self.ctx, timeout=10
-                    ) as response:
-                        self.assertEqual(
-                            response.getcode(),
-                            200,
-                            "Nginx must serve precompressed static files.",
+            app_url = urlsplit(self.live_server_url)
+            for scheme in ("http", "https"):
+                static_url = urlunsplit(
+                    (scheme, app_url.netloc, "/static/precompressed-static.txt", "", "")
+                )
+                for encoding, extension in (("br", "br"), ("gzip", "gz")):
+                    with self.subTest(scheme=scheme, encoding=encoding):
+                        request_info = request.Request(
+                            static_url,
+                            headers={"Accept-Encoding": encoding},
                         )
-                        self.assertEqual(
-                            response.headers.get("Content-Encoding"),
-                            encoding,
-                            "Nginx must honor the requested static file encoding.",
-                        )
-                        self.assertEqual(
-                            response.read(),
-                            ASSETS[f"precompressed-static.txt.{extension}"],
-                            "Nginx must serve the precompressed asset, "
-                            "not its fallback.",
-                        )
+                        with request.urlopen(
+                            request_info, context=self.ctx, timeout=10
+                        ) as response:
+                            self.assertEqual(
+                                response.getcode(),
+                                200,
+                                "Nginx must serve precompressed static files.",
+                            )
+                            self.assertEqual(
+                                response.headers.get("Content-Encoding"),
+                                encoding,
+                                "Nginx must honor the requested static file encoding.",
+                            )
+                            self.assertEqual(
+                                response.read(),
+                                ASSETS[f"precompressed-static.txt.{extension}"],
+                                "Nginx must serve the precompressed asset, "
+                                "not its fallback.",
+                            )
         finally:
             self._execute_docker_compose_command(
                 [

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -464,6 +464,33 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
     def test_nginx_serves_precompressed_static_files(self):
         script = Path(__file__).parent / "scripts" / "precompress_static.py"
         path = "/opt/openwisp/static/precompressed-static.txt"
+        custom_nginx_directory = Path(self.root_location) / "customization" / "nginx"
+        custom_static_directory = custom_nginx_directory / "static"
+        custom_path = custom_static_directory / "precompressed-static.txt"
+        custom_assets = {
+            "br": (
+                b"\x1b \x00\xf8\x8dT\xb5\xbf\x1ek\x83\x93\x93 eoI\x08#\xb5\xf4\x15\x94"
+                b"\xccc\x12\\"
+                b"\xc7\xe6\xa1\xec\x01"
+            ),
+            "gzip": (
+                b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xffK.-.\xc9\xcfU((JM"
+                b"\xce\xcf\x05\x92"
+                b"\xc5\xc5\xa9)\n\xc5%\x89%\x99\xc9\n\x89@N\t"
+                b"\x00i\xf5y\x8e!\x00\x00\x00"
+            ),
+        }
+        custom_files = {
+            custom_path: b"custom static asset",
+            Path(f"{custom_path}.br"): custom_assets["br"],
+            Path(f"{custom_path}.gz"): custom_assets["gzip"],
+        }
+        original_custom_files = {
+            file_path: file_path.read_bytes() if file_path.exists() else None
+            for file_path in custom_files
+        }
+        custom_nginx_directory_existed = custom_nginx_directory.exists()
+        custom_static_directory_existed = custom_static_directory.exists()
         self._execute_docker_compose_command(
             [
                 "docker",
@@ -481,36 +508,63 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
         )
         try:
             app_url = urlsplit(self.live_server_url)
-            for scheme in ("http", "https"):
-                static_url = urlunsplit(
-                    (scheme, app_url.netloc, "/static/precompressed-static.txt", "", "")
-                )
-                for encoding, extension in (("br", "br"), ("gzip", "gz")):
-                    with self.subTest(scheme=scheme, encoding=encoding):
-                        request_info = request.Request(
-                            static_url,
-                            headers={"Accept-Encoding": encoding},
-                        )
-                        with request.urlopen(
-                            request_info, context=self.ctx, timeout=10
-                        ) as response:
-                            self.assertEqual(
-                                response.getcode(),
-                                200,
-                                "Nginx must serve precompressed static files.",
+            static_url = urlunsplit(
+                ("https", app_url.netloc, "/static/precompressed-static.txt", "", "")
+            )
+
+            def assert_precompressed_assets(expected_assets, location):
+                for scheme in ("http", "https"):
+                    url = static_url.replace("https", scheme, 1)
+                    for encoding in ("br", "gzip"):
+                        with self.subTest(
+                            location=location, scheme=scheme, encoding=encoding
+                        ):
+                            request_info = request.Request(
+                                url,
+                                headers={"Accept-Encoding": encoding},
                             )
-                            self.assertEqual(
-                                response.headers.get("Content-Encoding"),
-                                encoding,
-                                "Nginx must honor the requested static file encoding.",
-                            )
-                            self.assertEqual(
-                                response.read(),
-                                ASSETS[f"precompressed-static.txt.{extension}"],
-                                "Nginx must serve the precompressed asset, "
-                                "not its fallback.",
-                            )
+                            with request.urlopen(
+                                request_info, context=self.ctx, timeout=10
+                            ) as response:
+                                self.assertEqual(
+                                    response.getcode(),
+                                    200,
+                                    "Nginx must serve precompressed static files.",
+                                )
+                                self.assertEqual(
+                                    response.headers.get("Content-Encoding"),
+                                    encoding,
+                                    "Nginx must honor the requested static file "
+                                    "encoding.",
+                                )
+                                self.assertEqual(
+                                    response.read(),
+                                    expected_assets[encoding],
+                                    "Nginx must serve the precompressed asset, "
+                                    "not its fallback.",
+                                )
+
+            assert_precompressed_assets(
+                {
+                    "br": ASSETS[f"{custom_path.name}.br"],
+                    "gzip": ASSETS[f"{custom_path.name}.gz"],
+                },
+                "shared",
+            )
+            custom_static_directory.mkdir(parents=True, exist_ok=True)
+            for file_path, content in custom_files.items():
+                file_path.write_bytes(content)
+            assert_precompressed_assets(custom_assets, "custom")
         finally:
+            for file_path, content in original_custom_files.items():
+                if content is None:
+                    file_path.unlink(missing_ok=True)
+                else:
+                    file_path.write_bytes(content)
+            if not custom_static_directory_existed and custom_static_directory.exists():
+                custom_static_directory.rmdir()
+            if not custom_nginx_directory_existed and custom_nginx_directory.exists():
+                custom_nginx_directory.rmdir()
             self._execute_docker_compose_command(
                 [
                     "docker",

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -11,6 +11,7 @@ from urllib import request
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
+from scripts.precompress_static import ASSETS
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -454,6 +455,66 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             ".getPropertyValue('--openwisp-test');"
         )
         self.assertEqual(value.strip(), self.custom_static_token)
+
+    def test_nginx_serves_precompressed_static_files(self):
+        script = Path(__file__).parent / "scripts" / "precompress_static.py"
+        path = "/opt/openwisp/static/precompressed-static.txt"
+        self._execute_docker_compose_command(
+            [
+                "docker",
+                "compose",
+                "run",
+                "--rm",
+                "--no-deps",
+                "--volume",
+                f"{script}:/test_precompress_static.py:ro",
+                "--entrypoint",
+                "python",
+                "dashboard",
+                "/test_precompress_static.py",
+            ]
+        )
+        try:
+            for encoding, extension in (("br", "br"), ("gzip", "gz")):
+                with self.subTest(encoding=encoding):
+                    request_info = request.Request(
+                        f"{self.live_server_url}/static/precompressed-static.txt",
+                        headers={"Accept-Encoding": encoding},
+                    )
+                    with request.urlopen(
+                        request_info, context=self.ctx, timeout=10
+                    ) as response:
+                        self.assertEqual(
+                            response.getcode(),
+                            200,
+                            "Nginx must serve precompressed static files.",
+                        )
+                        self.assertEqual(
+                            response.headers.get("Content-Encoding"),
+                            encoding,
+                            "Nginx must honor the requested static file encoding.",
+                        )
+                        self.assertEqual(
+                            response.read(),
+                            ASSETS[f"precompressed-static.txt.{extension}"],
+                            "Nginx must serve the precompressed asset, "
+                            "not its fallback.",
+                        )
+        finally:
+            self._execute_docker_compose_command(
+                [
+                    "docker",
+                    "compose",
+                    "exec",
+                    "-T",
+                    "dashboard",
+                    "rm",
+                    "-f",
+                    path,
+                    f"{path}.br",
+                    f"{path}.gz",
+                ]
+            )
 
     def test_device_monitoring_charts(self):
         self.login()

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1409,6 +1409,11 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
             "/tmp/nginx_signing_key_details || exit 1;",
             dockerfile,
         )
+        self.assertRegex(
+            dockerfile,
+            r"cmp -s /tmp/nginx_actual_primary_fingerprints \\\s+"
+            r"/tmp/nginx_expected_primary_fingerprints",
+        )
         for key, fingerprint in (
             ("arut", "43387825DDB1BB97EC36BA5D007C8D7C15D87369"),
             ("pluknet", "D6786CE303D9A9022998DC6CC8464D549AF75C0A"),

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1404,6 +1404,11 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
         self.assertNotIn("NGINX_TARBALL_SHA256", dockerfile)
         self.assertIn("nginx-${NGINX_VERSION}.tar.gz.asc", dockerfile)
         self.assertIn("gpg --batch --verify", dockerfile)
+        self.assertIn(
+            'grep -Fqx "fpr:::::::::${fingerprint}:" '
+            "/tmp/nginx_signing_key_details || exit 1;",
+            dockerfile,
+        )
         for key, fingerprint in (
             ("arut", "43387825DDB1BB97EC36BA5D007C8D7C15D87369"),
             ("pluknet", "D6786CE303D9A9022998DC6CC8464D549AF75C0A"),

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1414,47 +1414,58 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 self.assertIn(f"nginx.org/keys/{key}.key", dockerfile)
                 self.assertIn(fingerprint, dockerfile)
 
-    def test_admin_theme_cleanup_restores_existing_css(self):
-        """Ensure test cleanup restores existing CSS.
+    def test_admin_theme_cleanup_handles_custom_css(self):
+        """Ensure test cleanup preserves user CSS and removes generated files.
 
-        This prevents test cleanup from deleting user customizations.
+        This prevents test cleanup from deleting user customizations or
+        leaving test files in the theme directory.
         """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            css_path = (
-                root / "customization" / "theme" / "custom" / "custom-openwisp-test.css"
-            )
-            css_path.parent.mkdir(parents=True)
-            original_css = b"/* existing custom theme */\n"
-            css_path.write_bytes(original_css)
+        for custom_css_exists in (True, False):
+            with self.subTest(custom_css_exists=custom_css_exists):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    css_path = (
+                        root
+                        / "customization"
+                        / "theme"
+                        / "custom"
+                        / "custom-openwisp-test.css"
+                    )
+                    original_css = b"/* existing custom theme */\n"
+                    if custom_css_exists:
+                        css_path.parent.mkdir(parents=True)
+                        css_path.write_bytes(original_css)
 
-            class CleanupTestServices(TestServices):
-                pass
+                    class CleanupTestServices(TestServices):
+                        pass
 
-            CleanupTestServices.custom_settings_path = root / "settings.py"
-            CleanupTestServices.custom_settings_path.write_text("")
-            CleanupTestServices.root_location = root
-            CleanupTestServices.config = {
-                "app_url": "https://dashboard.openwisp.org",
-                "custom_css_filename": css_path.name,
-                "services_delay_retries": 0,
-                "services_max_retries": 1,
-            }
-            with mock.patch.object(
-                CleanupTestServices, "addClassCleanup"
-            ), mock.patch.object(
-                CleanupTestServices, "reverse_url", return_value="/admin/login/"
-            ), mock.patch.object(
-                CleanupTestServices,
-                "_execute_docker_compose_command",
-                return_value=("", ""),
-            ), mock.patch.object(
-                request, "urlopen", return_value=mock.Mock()
-            ):
-                CleanupTestServices._setup_admin_theme_links()
-                self.assertNotEqual(css_path.read_bytes(), original_css)
-                CleanupTestServices._cleanup_admin_theme_links()
-            self.assertEqual(css_path.read_bytes(), original_css)
+                    CleanupTestServices.custom_settings_path = root / "settings.py"
+                    CleanupTestServices.custom_settings_path.write_text("")
+                    CleanupTestServices.root_location = root
+                    CleanupTestServices.config = {
+                        "app_url": "https://dashboard.openwisp.org",
+                        "custom_css_filename": css_path.name,
+                        "services_delay_retries": 0,
+                        "services_max_retries": 1,
+                    }
+                    with mock.patch.object(
+                        CleanupTestServices, "addClassCleanup"
+                    ), mock.patch.object(
+                        CleanupTestServices, "reverse_url", return_value="/admin/login/"
+                    ), mock.patch.object(
+                        CleanupTestServices,
+                        "_execute_docker_compose_command",
+                        return_value=("", ""),
+                    ), mock.patch.object(
+                        request, "urlopen", return_value=mock.Mock()
+                    ):
+                        CleanupTestServices._setup_admin_theme_links()
+                        CleanupTestServices._cleanup_admin_theme_links()
+                    if custom_css_exists:
+                        self.assertEqual(css_path.read_bytes(), original_css)
+                    else:
+                        self.assertFalse(css_path.exists())
+                        self.assertFalse(css_path.parent.exists())
 
 
 class TestOpenVPN(unittest.TestCase):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1061,54 +1061,6 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
 class TestLocalUtils(BaseTestUtils, unittest.TestCase):
     """Tests for local utilities"""
 
-    def test_nginx_source_verification_tracks_version(self):
-        """Ensure Dependabot Nginx bumps retain source authentication."""
-        dockerfile = (
-            Path(self.root_location) / "images" / "openwisp_nginx" / "Dockerfile"
-        ).read_text()
-        self.assertNotIn("NGINX_TARBALL_SHA256", dockerfile)
-        self.assertIn("nginx-${NGINX_VERSION}.tar.gz.asc", dockerfile)
-        self.assertIn("gpg --batch --verify", dockerfile)
-
-    def test_admin_theme_cleanup_restores_existing_css(self):
-        """Ensure theme setup does not remove a pre-existing custom CSS file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            root = Path(tmpdir)
-            css_path = (
-                root / "customization" / "theme" / "custom" / "custom-openwisp-test.css"
-            )
-            css_path.parent.mkdir(parents=True)
-            original_css = b"/* existing custom theme */\n"
-            css_path.write_bytes(original_css)
-
-            class CleanupTestServices(TestServices):
-                pass
-
-            CleanupTestServices.custom_settings_path = root / "settings.py"
-            CleanupTestServices.custom_settings_path.write_text("")
-            CleanupTestServices.root_location = root
-            CleanupTestServices.config = {
-                "app_url": "https://dashboard.openwisp.org",
-                "custom_css_filename": css_path.name,
-                "services_delay_retries": 0,
-                "services_max_retries": 1,
-            }
-            with mock.patch.object(
-                CleanupTestServices, "addClassCleanup"
-            ), mock.patch.object(
-                CleanupTestServices, "reverse_url", return_value="/admin/login/"
-            ), mock.patch.object(
-                CleanupTestServices,
-                "_execute_docker_compose_command",
-                return_value=("", ""),
-            ), mock.patch.object(
-                request, "urlopen", return_value=mock.Mock()
-            ):
-                CleanupTestServices._setup_admin_theme_links()
-                self.assertNotEqual(css_path.read_bytes(), original_css)
-                CleanupTestServices._cleanup_admin_theme_links()
-            self.assertEqual(css_path.read_bytes(), original_css)
-
     def test_profile_configures_shell_defaults_and_preserves_overrides(self):
         for dev_mode, settings, expected in (
             (
@@ -1443,6 +1395,66 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
                 self.assertEqual(result.stdout, expected)
+
+    def test_nginx_source_verification_tracks_version(self):
+        """Ensure Dependabot Nginx bumps retain source authentication."""
+        dockerfile = (
+            Path(self.root_location) / "images" / "openwisp_nginx" / "Dockerfile"
+        ).read_text()
+        self.assertNotIn("NGINX_TARBALL_SHA256", dockerfile)
+        self.assertIn("nginx-${NGINX_VERSION}.tar.gz.asc", dockerfile)
+        self.assertIn("gpg --batch --verify", dockerfile)
+        for key, fingerprint in (
+            ("arut", "43387825DDB1BB97EC36BA5D007C8D7C15D87369"),
+            ("pluknet", "D6786CE303D9A9022998DC6CC8464D549AF75C0A"),
+            ("sb", "7338973069ED3F443F4D37DFA64FD5B17ADB39A8"),
+            ("thresh", "13C82A63B603576156E30A4EA0EA981B66B0D967"),
+        ):
+            with self.subTest(key=key):
+                self.assertIn(f"nginx.org/keys/{key}.key", dockerfile)
+                self.assertIn(fingerprint, dockerfile)
+
+    def test_admin_theme_cleanup_restores_existing_css(self):
+        """Ensure test cleanup restores existing CSS.
+
+        This prevents test cleanup from deleting user customizations.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            css_path = (
+                root / "customization" / "theme" / "custom" / "custom-openwisp-test.css"
+            )
+            css_path.parent.mkdir(parents=True)
+            original_css = b"/* existing custom theme */\n"
+            css_path.write_bytes(original_css)
+
+            class CleanupTestServices(TestServices):
+                pass
+
+            CleanupTestServices.custom_settings_path = root / "settings.py"
+            CleanupTestServices.custom_settings_path.write_text("")
+            CleanupTestServices.root_location = root
+            CleanupTestServices.config = {
+                "app_url": "https://dashboard.openwisp.org",
+                "custom_css_filename": css_path.name,
+                "services_delay_retries": 0,
+                "services_max_retries": 1,
+            }
+            with mock.patch.object(
+                CleanupTestServices, "addClassCleanup"
+            ), mock.patch.object(
+                CleanupTestServices, "reverse_url", return_value="/admin/login/"
+            ), mock.patch.object(
+                CleanupTestServices,
+                "_execute_docker_compose_command",
+                return_value=("", ""),
+            ), mock.patch.object(
+                request, "urlopen", return_value=mock.Mock()
+            ):
+                CleanupTestServices._setup_admin_theme_links()
+                self.assertNotEqual(css_path.read_bytes(), original_css)
+                CleanupTestServices._cleanup_admin_theme_links()
+            self.assertEqual(css_path.read_bytes(), original_css)
 
 
 class TestOpenVPN(unittest.TestCase):

--- a/tests/scripts/precompress_static.py
+++ b/tests/scripts/precompress_static.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ASSETS = {
+    "precompressed-static.txt": b"uncompressed static asset",
+    "precompressed-static.txt.br": b"\x8b\x0c\x80precompressed Brotli asset\x03",
+    "precompressed-static.txt.gz": (
+        b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\xff+(JM\xce\xcf-(J-.N"
+        b"MQH\xaf\xca,PH\x042K\x00\xabO\xa0B\x18\x00\x00\x00"
+    ),
+}
+
+
+if __name__ == "__main__":
+    static_dir = Path("/opt/openwisp/static")
+    for filename, content in ASSETS.items():
+        static_dir.joinpath(filename).write_bytes(content)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #560.

## Description of Changes

Builds and loads the Nginx Brotli static module against the Nginx version used by the official Alpine image. The module source is pinned to an immutable commit and the Nginx archive is verified before building. Static locations preserve custom-first resolution while using `gzip_static` and `brotli_static`, allowing Nginx to select pre-generated `.gz` or `.br` assets without compressing responses at request time.

Removes obsolete Django compression settings that the current static-files storage backend no longer reads and documents the `NGINX_BROTLI_SWITCH` setting.

Adds a Compose integration test that writes deliberately different fallback, Brotli, and gzip assets to the shared static volume. It verifies the response encoding and exact served bytes for both Brotli and gzip.

## Screenshot

Not applicable. This is a server-side static-file delivery change.