### PR TITLE
[fix] Fixed Docker Hub image pulls #669

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,4 +135,4 @@ jobs:
       - name: Publish to GitLab Container Registry
         if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
-          make publish TAG=edge SKIP_BUILD=true SKIP_TESTS=true
+          make publish USER=registry.gitlab.com/openwisp/docker-openwisp TAG=edge SKIP_BUILD=true SKIP_TESTS=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Release to GitLab Container Registry
         run: |
-          make release SKIP_BUILD=true
+          make release USER=registry.gitlab.com/openwisp/docker-openwisp SKIP_BUILD=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,21 +38,28 @@ If instructions conflict, repository config and CI workflows win first, docs nex
 - Follow the DRY principle: do not duplicate information or code across files.
 - Preserve Docker image contracts, compose service names, environment variables, volumes, ports, and upgrade paths unless explicitly required.
 - Be careful with shell scripts, Docker layers, permissions, entrypoints, health checks, and generated configuration.
+- Place Python imports at the top of the file. Defer imports only when necessary, such as when an import depends on runtime initialization.
 - Avoid unnecessary blank lines inside functions or shell blocks.
 - Prefer short, precise names that rely on their nearest meaningful scope. Do not repeat a feature, domain object, or namespace already named by the containing module, class, or function. For example, prefer `EstimatedLocation.refresh()` over `EstimatedLocation.refresh_estimated_location()`. Repeat that context only when the name is used outside that scope or is needed to distinguish genuinely different concepts. When a concise name cannot express a necessary distinction, use a concise docstring to describe it rather than encoding it in an excessively long name.
-- Before adding a comment or docstring, ask whether it conveys information a reader cannot reasonably infer from clear code, names, and surrounding scope. Add a concise comment when it explains a non-obvious reason, constraint, compatibility or security requirement, side effect, or unavoidable complexity. In opaque syntax or domain-specific code, especially shell scripts, a comment may also explain what the code does. Do not add comments that merely restate adjacent code one-to-one.
+- Before adding a comment or docstring, ask whether it conveys information a reader cannot reasonably infer from clear code, names, and surrounding scope. Add a concise comment when it explains a non-obvious reason, constraint, compatibility or security requirement, side effect, or unavoidable complexity. In opaque syntax or domain-specific code, especially shell scripts, a comment may also explain what the code does. Do not add comments that merely restate adjacent code one-to-one. Place comments before the relevant block instead of scattering them inside it.
 - Update docs when behavior, settings, environment variables, deployment steps, or supported versions change, including when a documented feature's behavior changes or a new user-facing feature is added.
 - Review documentation examples and references when behavior changes.
 - Preserve public documentation anchors, URLs, include directives, and versioned links unless explicitly required.
 
 ## Testing and QA
 
+- For complex or long tests, add a docstring when a longer test name would improve readability or maintainability.
+- When separate tests cover different cases of the same feature, share almost identical database preparation, and primarily vary in input or expected outcome, group them in one test method with `subTest`. Keep each subtest's setup explicit and independent, and retain separate test methods when cases exercise genuinely distinct behavior. Leave one blank line before each `with self.subTest(...)` statement only when a test method contains multiple such statements. Do not add a blank line for a single `subTest` statement inside a loop.
+- Prefer method decorators for context managers that apply to the entire test method and would otherwise create unnecessary nesting, unless decorator ordering conflicts or the context manager requires data unavailable when the method is defined.
 - Use targeted checks while iterating, then run the documented full QA/test command before considering the change complete.
+- During development, run focused tests and test suites directly affected by the change instead of routinely running the full suite.
+- Before pushing a behavior-affecting change, verify that the full test suite has passed for the current branch after its latest code, test, dependency, or configuration change. If the full suite cannot run, report the blocker and wait for direction.
 - Keep helpers and classes used by only one test method inside that method. Promote them to class or module scope only when genuinely reused.
+- Keep tests quiet on success. When code under test writes to stdout or stderr, capture and assert that output rather than leaving it unasserted.
 
 ## Security Rules
 
-- Watch for exposed secrets, unsafe defaults, insecure permissions, unsafe shell expansion, path traversal, and accidental public ports.
+- Watch for exposed secrets, unsafe defaults, insecure permissions, unsafe shell expansion or command strings, path traversal, and accidental public ports.
 - Preserve validation and safe handling around environment files, mounted volumes, TLS material, credentials, and service configuration.
 - Prevent secret disclosure, unsafe deployment instructions, stale security guidance, and insecure links.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,28 +38,21 @@ If instructions conflict, repository config and CI workflows win first, docs nex
 - Follow the DRY principle: do not duplicate information or code across files.
 - Preserve Docker image contracts, compose service names, environment variables, volumes, ports, and upgrade paths unless explicitly required.
 - Be careful with shell scripts, Docker layers, permissions, entrypoints, health checks, and generated configuration.
-- Place Python imports at the top of the file. Defer imports only when necessary, such as when an import depends on runtime initialization.
 - Avoid unnecessary blank lines inside functions or shell blocks.
 - Prefer short, precise names that rely on their nearest meaningful scope. Do not repeat a feature, domain object, or namespace already named by the containing module, class, or function. For example, prefer `EstimatedLocation.refresh()` over `EstimatedLocation.refresh_estimated_location()`. Repeat that context only when the name is used outside that scope or is needed to distinguish genuinely different concepts. When a concise name cannot express a necessary distinction, use a concise docstring to describe it rather than encoding it in an excessively long name.
-- Before adding a comment or docstring, ask whether it conveys information a reader cannot reasonably infer from clear code, names, and surrounding scope. Add a concise comment when it explains a non-obvious reason, constraint, compatibility or security requirement, side effect, or unavoidable complexity. In opaque syntax or domain-specific code, especially shell scripts, a comment may also explain what the code does. Do not add comments that merely restate adjacent code one-to-one. Place comments before the relevant block instead of scattering them inside it.
+- Before adding a comment or docstring, ask whether it conveys information a reader cannot reasonably infer from clear code, names, and surrounding scope. Add a concise comment when it explains a non-obvious reason, constraint, compatibility or security requirement, side effect, or unavoidable complexity. In opaque syntax or domain-specific code, especially shell scripts, a comment may also explain what the code does. Do not add comments that merely restate adjacent code one-to-one.
 - Update docs when behavior, settings, environment variables, deployment steps, or supported versions change, including when a documented feature's behavior changes or a new user-facing feature is added.
 - Review documentation examples and references when behavior changes.
 - Preserve public documentation anchors, URLs, include directives, and versioned links unless explicitly required.
 
 ## Testing and QA
 
-- For complex or long tests, add a docstring when a longer test name would improve readability or maintainability.
-- When separate tests cover different cases of the same feature, share almost identical database preparation, and primarily vary in input or expected outcome, group them in one test method with `subTest`. Keep each subtest's setup explicit and independent, and retain separate test methods when cases exercise genuinely distinct behavior. Leave one blank line before each `with self.subTest(...)` statement only when a test method contains multiple such statements. Do not add a blank line for a single `subTest` statement inside a loop.
-- Prefer method decorators for context managers that apply to the entire test method and would otherwise create unnecessary nesting, unless decorator ordering conflicts or the context manager requires data unavailable when the method is defined.
 - Use targeted checks while iterating, then run the documented full QA/test command before considering the change complete.
-- During development, run focused tests and test suites directly affected by the change instead of routinely running the full suite.
-- Before pushing a behavior-affecting change, verify that the full test suite has passed for the current branch after its latest code, test, dependency, or configuration change. If the full suite cannot run, report the blocker and wait for direction.
 - Keep helpers and classes used by only one test method inside that method. Promote them to class or module scope only when genuinely reused.
-- Keep tests quiet on success. When code under test writes to stdout or stderr, capture and assert that output rather than leaving it unasserted.
 
 ## Security Rules
 
-- Watch for exposed secrets, unsafe defaults, insecure permissions, unsafe shell expansion or command strings, path traversal, and accidental public ports.
+- Watch for exposed secrets, unsafe defaults, insecure permissions, unsafe shell expansion, path traversal, and accidental public ports.
 - Preserve validation and safe handling around environment files, mounted volumes, TLS material, credentials, and service configuration.
 - Prevent secret disclosure, unsafe deployment instructions, stale security guidance, and insecure links.
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 default: compose-build
 
-USER = registry.gitlab.com/openwisp/docker-openwisp
+USER = docker.io/openwisp
 TAG = edge
 # OPENWISP_VERSION: image tag used for pulling/pushing images (e.g. "edge", "latest", "25.10.0")
 # Can be overridden via .env or command line. Not the same as RELEASE_VERSION
@@ -27,8 +27,8 @@ pull:
 	for image in 'openwisp-base' 'openwisp-nfs' 'openwisp-api' 'openwisp-dashboard' \
 				 'openwisp-freeradius' 'openwisp-nginx' 'openwisp-openvpn' 'openwisp-postfix' \
 				 'openwisp-websocket' ; do \
-		docker pull --quiet $(USER)/$${image}:$(OPENWISP_VERSION); \
-		docker tag  $(USER)/$${image}:$(OPENWISP_VERSION) $(IMAGE_OWNER)/$${image}:$(OPENWISP_VERSION); \
+		docker pull --quiet $(USER)/$${image}:$(OPENWISP_VERSION) || exit 1; \
+		docker tag $(USER)/$${image}:$(OPENWISP_VERSION) $(IMAGE_OWNER)/$${image}:$(OPENWISP_VERSION) || exit 1; \
 	done
 
 # Build
@@ -115,11 +115,8 @@ publish:
 	for image in 'openwisp-base' 'openwisp-nfs' 'openwisp-api' 'openwisp-dashboard' \
 				 'openwisp-freeradius' 'openwisp-nginx' 'openwisp-openvpn' 'openwisp-postfix' \
 				 'openwisp-websocket' ; do \
-		docker tag $(IMAGE_OWNER)/$${image}:$(OPENWISP_VERSION) $(USER)/$${image}:$(TAG); \
-		docker push $(USER)/$${image}:$(TAG); \
-		if [ "$(TAG)" != "latest" ]; then \
-			docker rmi $(USER)/$${image}:$(TAG); \
-		fi; \
+		docker tag $(IMAGE_OWNER)/$${image}:$(OPENWISP_VERSION) $(USER)/$${image}:$(TAG) || exit 1; \
+		docker push $(USER)/$${image}:$(TAG) || exit 1; \
 	done
 
 release:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -14,6 +14,7 @@ Available Images
 The images are hosted on `Docker Hub
 <https://hub.docker.com/u/openwisp>`__ and `GitLab Container Registry
 <https://gitlab.com/openwisp/docker-openwisp/container_registry>`__.
+Docker Hub is the default image source used by the deployment.
 
 Image Tags
 ~~~~~~~~~~

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -477,7 +477,7 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             ).communicate()
 
     def test_containers_down(self):
-        """Ensure all Compose services are running."""
+        """Ensure Compose succeeds and no container has stopped."""
         cmd = subprocess.Popen(
             ["docker", "compose", "ps"],
             universal_newlines=True,
@@ -485,10 +485,11 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             stderr=subprocess.PIPE,
             cwd=self.root_location,
         )
-        output, error = map(str, cmd.communicate())
+        output, error = cmd.communicate()
+        self.assertEqual(cmd.returncode, 0, error)
         if "Exit" in output:
             self.fail(
-                f"One of the containers are down!\nOutput:\n{output}\nError:\n{error}"
+                f"One of the containers is down!\nOutput:\n{output}\nError:\n{error}"
             )
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -494,6 +494,97 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
 class TestLocalUtils(BaseTestUtils, unittest.TestCase):
     """Tests for local utilities"""
 
+    def test_makefile_pulls_from_docker_hub_and_fails_on_publish_error(self):
+        repository_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            bin_directory = tmpdir / "bin"
+            bin_directory.mkdir()
+            docker_log = tmpdir / "docker.log"
+            docker_command = bin_directory / "docker"
+            docker_command.write_text(
+                "#!/bin/bash\n"
+                'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
+                'if [ "$1" = "push" ] && [ "$FAIL_PUSH" = "true" ]; then\n'
+                "    exit 1\n"
+                "fi\n"
+            )
+            docker_command.chmod(0o755)
+            (tmpdir / "Makefile").write_text((repository_root / "Makefile").read_text())
+            (tmpdir / ".env").write_text("")
+            environment = os.environ.copy()
+            environment["DOCKER_LOG"] = str(docker_log)
+            environment["PATH"] = f"{bin_directory}:{environment['PATH']}"
+            pull = subprocess.run(
+                ["make", "pull", "OPENWISP_VERSION=25.10.4"],
+                cwd=tmpdir,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(pull.returncode, 0, pull.stderr)
+            commands = docker_log.read_text().splitlines()
+            self.assertEqual(
+                len(commands), 18, "The Makefile must pull and tag all images."
+            )
+            self.assertTrue(
+                all(
+                    command.startswith("pull --quiet docker.io/openwisp/")
+                    for command in commands[::2]
+                ),
+                "The default pull registry must be Docker Hub.",
+            )
+
+            docker_log.write_text("")
+            publish = subprocess.run(
+                [
+                    "make",
+                    "publish",
+                    "USER=docker.io/openwisp",
+                    "TAG=25.10.4",
+                    "OPENWISP_VERSION=25.10.4",
+                    "SKIP_BUILD=true",
+                    "SKIP_TESTS=true",
+                ],
+                cwd=tmpdir,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(publish.returncode, 0, publish.stderr)
+            self.assertFalse(
+                any(
+                    command.startswith("rmi ")
+                    for command in docker_log.read_text().splitlines()
+                ),
+                "Publishing must retain the source tags for another registry.",
+            )
+
+            environment["FAIL_PUSH"] = "true"
+            failed_publish = subprocess.run(
+                [
+                    "make",
+                    "publish",
+                    "USER=registry.gitlab.com/openwisp/docker-openwisp",
+                    "TAG=25.10.4",
+                    "OPENWISP_VERSION=25.10.4",
+                    "SKIP_BUILD=true",
+                    "SKIP_TESTS=true",
+                ],
+                cwd=tmpdir,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertNotEqual(
+                failed_publish.returncode,
+                0,
+                "A failed registry upload must fail make publish.",
+            )
+
     def test_update_version_updates_only_version_file(self):
         repository_root = Path(__file__).resolve().parents[1]
         makefile_content = (

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -265,6 +265,7 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
         )
 
     def test_console_errors(self):
+        """Ensure key account and admin pages have no browser console errors."""
         url_list = [
             "/admin/",
             "/accounts/password/reset/",
@@ -298,16 +299,16 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
         ]
         self.login()
         self.create_superuser("sample@email.com", "test_superuser2")
-        # url_list tests
         for url in url_list:
-            self.open(url)
-            self.assertEqual([], self.console_error_check())
-            self.assertIn("OpenWISP", self.base_driver.title)
-        # change_form_list tests
+            with self.subTest(url=url):
+                self.open(url)
+                self.assertEqual([], self.console_error_check())
+                self.assertIn("OpenWISP", self.base_driver.title)
         for change_form in change_form_list:
-            self.get_resource(*change_form)
-            self.assertEqual([], self.console_error_check())
-            self.assertIn("OpenWISP", self.base_driver.title)
+            with self.subTest(resource=change_form[0], path=change_form[1]):
+                self.get_resource(*change_form)
+                self.assertEqual([], self.console_error_check())
+                self.assertIn("OpenWISP", self.base_driver.title)
 
     def test_add_superuser(self):
         """Create new user to ensure a new user can be added."""
@@ -476,7 +477,7 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
             ).communicate()
 
     def test_containers_down(self):
-        """Ensure freeradius service is working correctly."""
+        """Ensure all Compose services are running."""
         cmd = subprocess.Popen(
             ["docker", "compose", "ps"],
             universal_newlines=True,
@@ -511,6 +512,7 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
         )
 
     def test_makefile_pulls_from_docker_hub_and_fails_on_image_command_error(self):
+        """Verify Docker Hub pulls and Makefile command failure propagation."""
         repository_root = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
@@ -556,21 +558,15 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 "The default pull registry must be Docker Hub.",
             )
 
-            environment["FAIL_COMMAND"] = "pull"
-            failed_pull = run_make("pull", "OPENWISP_VERSION=25.10.4")
-            self.assertNotEqual(
-                failed_pull.returncode,
-                0,
-                "A failed image pull must fail make pull.",
-            )
-
-            environment["FAIL_COMMAND"] = "tag"
-            failed_pull_tag = run_make("pull", "OPENWISP_VERSION=25.10.4")
-            self.assertNotEqual(
-                failed_pull_tag.returncode,
-                0,
-                "A failed image tag must fail make pull.",
-            )
+            for command in ("pull", "tag"):
+                with self.subTest(target="pull", command=command):
+                    environment["FAIL_COMMAND"] = command
+                    failed_pull = run_make("pull", "OPENWISP_VERSION=25.10.4")
+                    self.assertNotEqual(
+                        failed_pull.returncode,
+                        0,
+                        f"A failed image {command} must fail make pull.",
+                    )
 
             environment.pop("FAIL_COMMAND")
             docker_log.write_text("")
@@ -592,23 +588,18 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 "Publishing must retain the source tags for another registry.",
             )
 
-            environment["FAIL_COMMAND"] = "tag"
-            failed_publish_tag = run_make(*publish_arguments)
-            self.assertNotEqual(
-                failed_publish_tag.returncode,
-                0,
-                "A failed image tag must fail make publish.",
-            )
-
-            environment["FAIL_COMMAND"] = "push"
-            failed_publish = run_make(*publish_arguments)
-            self.assertNotEqual(
-                failed_publish.returncode,
-                0,
-                "A failed registry upload must fail make publish.",
-            )
+            for command in ("tag", "push"):
+                with self.subTest(target="publish", command=command):
+                    environment["FAIL_COMMAND"] = command
+                    failed_publish = run_make(*publish_arguments)
+                    self.assertNotEqual(
+                        failed_publish.returncode,
+                        0,
+                        f"A failed image {command} must fail make publish.",
+                    )
 
     def test_update_version_updates_only_version_file(self):
+        """Verify version updates and rejected legacy bump commands."""
         repository_root = Path(__file__).resolve().parents[1]
         makefile_content = (
             "RELEASE_VERSION = $(shell cat images/common/openwisp/VERSION)\n"
@@ -622,36 +613,39 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
             makefile.write_text((repository_root / "Makefile").read_text())
             (tmpdir / ".env").write_text("")
             (tmpdir / "build.py").write_text((repository_root / "build.py").read_text())
-            result = subprocess.run(
-                ["make", "bump", "VERSION=26.01.0"],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            missing_argument = subprocess.run(
-                ["make", "bump"],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            old_target = subprocess.run(
-                [
-                    "make",
-                    "bump-version",
-                ],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertNotEqual(missing_argument.returncode, 0)
-            self.assertNotEqual(old_target.returncode, 0)
-            self.assertEqual(version_file.read_text(), "26.01.0\n")
-            self.assertIn(makefile_content, makefile.read_text())
-            self.assertFalse((version_file.parent / "_version.py").exists())
+
+            with self.subTest(command="bump with version"):
+                result = subprocess.run(
+                    ["make", "bump", "VERSION=26.01.0"],
+                    cwd=tmpdir,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(version_file.read_text(), "26.01.0\n")
+                self.assertIn(makefile_content, makefile.read_text())
+                self.assertFalse((version_file.parent / "_version.py").exists())
+
+            with self.subTest(command="bump without version"):
+                missing_argument = subprocess.run(
+                    ["make", "bump"],
+                    cwd=tmpdir,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(missing_argument.returncode, 0)
+
+            with self.subTest(command="legacy bump-version"):
+                old_target = subprocess.run(
+                    ["make", "bump-version"],
+                    cwd=tmpdir,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertNotEqual(old_target.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -494,7 +494,23 @@ class TestServices(FunctionalTestUtils, unittest.TestCase):
 class TestLocalUtils(BaseTestUtils, unittest.TestCase):
     """Tests for local utilities"""
 
-    def test_makefile_pulls_from_docker_hub_and_fails_on_publish_error(self):
+    def test_workflows_publish_to_gitlab_registry(self):
+        repository_root = Path(__file__).resolve().parents[1]
+        registry = "registry.gitlab.com/openwisp/docker-openwisp"
+        ci_workflow = (repository_root / ".github" / "workflows" / "ci.yml").read_text()
+        release_workflow = (
+            repository_root / ".github" / "workflows" / "release.yml"
+        ).read_text()
+        self.assertIn(
+            f"make publish USER={registry} TAG=edge SKIP_BUILD=true SKIP_TESTS=true",
+            ci_workflow,
+        )
+        self.assertIn(
+            f"make release USER={registry} SKIP_BUILD=true",
+            release_workflow,
+        )
+
+    def test_makefile_pulls_from_docker_hub_and_fails_on_image_command_error(self):
         repository_root = Path(__file__).resolve().parents[1]
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
@@ -505,7 +521,7 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
             docker_command.write_text(
                 "#!/bin/bash\n"
                 'printf "%s\\n" "$*" >> "$DOCKER_LOG"\n'
-                'if [ "$1" = "push" ] && [ "$FAIL_PUSH" = "true" ]; then\n'
+                'if [ "$1" = "$FAIL_COMMAND" ]; then\n'
                 "    exit 1\n"
                 "fi\n"
             )
@@ -515,14 +531,18 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
             environment = os.environ.copy()
             environment["DOCKER_LOG"] = str(docker_log)
             environment["PATH"] = f"{bin_directory}:{environment['PATH']}"
-            pull = subprocess.run(
-                ["make", "pull", "OPENWISP_VERSION=25.10.4"],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-                env=environment,
-            )
+
+            def run_make(*arguments):
+                return subprocess.run(
+                    ["make", *arguments],
+                    cwd=tmpdir,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+
+            pull = run_make("pull", "OPENWISP_VERSION=25.10.4")
             self.assertEqual(pull.returncode, 0, pull.stderr)
             commands = docker_log.read_text().splitlines()
             self.assertEqual(
@@ -536,23 +556,33 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 "The default pull registry must be Docker Hub.",
             )
 
-            docker_log.write_text("")
-            publish = subprocess.run(
-                [
-                    "make",
-                    "publish",
-                    "USER=docker.io/openwisp",
-                    "TAG=25.10.4",
-                    "OPENWISP_VERSION=25.10.4",
-                    "SKIP_BUILD=true",
-                    "SKIP_TESTS=true",
-                ],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-                env=environment,
+            environment["FAIL_COMMAND"] = "pull"
+            failed_pull = run_make("pull", "OPENWISP_VERSION=25.10.4")
+            self.assertNotEqual(
+                failed_pull.returncode,
+                0,
+                "A failed image pull must fail make pull.",
             )
+
+            environment["FAIL_COMMAND"] = "tag"
+            failed_pull_tag = run_make("pull", "OPENWISP_VERSION=25.10.4")
+            self.assertNotEqual(
+                failed_pull_tag.returncode,
+                0,
+                "A failed image tag must fail make pull.",
+            )
+
+            environment.pop("FAIL_COMMAND")
+            docker_log.write_text("")
+            publish_arguments = (
+                "publish",
+                "USER=docker.io/openwisp",
+                "TAG=25.10.4",
+                "OPENWISP_VERSION=25.10.4",
+                "SKIP_BUILD=true",
+                "SKIP_TESTS=true",
+            )
+            publish = run_make(*publish_arguments)
             self.assertEqual(publish.returncode, 0, publish.stderr)
             self.assertFalse(
                 any(
@@ -562,23 +592,16 @@ class TestLocalUtils(BaseTestUtils, unittest.TestCase):
                 "Publishing must retain the source tags for another registry.",
             )
 
-            environment["FAIL_PUSH"] = "true"
-            failed_publish = subprocess.run(
-                [
-                    "make",
-                    "publish",
-                    "USER=registry.gitlab.com/openwisp/docker-openwisp",
-                    "TAG=25.10.4",
-                    "OPENWISP_VERSION=25.10.4",
-                    "SKIP_BUILD=true",
-                    "SKIP_TESTS=true",
-                ],
-                cwd=tmpdir,
-                check=False,
-                capture_output=True,
-                text=True,
-                env=environment,
+            environment["FAIL_COMMAND"] = "tag"
+            failed_publish_tag = run_make(*publish_arguments)
+            self.assertNotEqual(
+                failed_publish_tag.returncode,
+                0,
+                "A failed image tag must fail make publish.",
             )
+
+            environment["FAIL_COMMAND"] = "push"
+            failed_publish = run_make(*publish_arguments)
             self.assertNotEqual(
                 failed_publish.returncode,
                 0,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #669.

## Description of Changes

Makes Docker Hub the default image source for Makefile pulls. Preserves locally built image tags until publishing to both registries is complete, and fails the publishing target when a registry command fails.

## Screenshot

N/A