### PR TITLE
[fix] Configured django-channels without Redis timeouts

### DIFF
--- a/images/common/openwisp/settings.py
+++ b/images/common/openwisp/settings.py
@@ -233,7 +233,7 @@ CHANNEL_LAYERS = {
             "hosts": [
                 {
                     "address": CHANNEL_REDIS_HOST,
-                    # Redis>=8 changed the default timeout of read
+                    # redis-py 8.0.0 changed the default timeout of socket
                     # operations to 5 seconds, which breaks django-channels,
                     # hence we need to explicitly remove the timeout.
                     "socket_timeout": None,

--- a/images/common/openwisp/settings.py
+++ b/images/common/openwisp/settings.py
@@ -231,7 +231,13 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [
-                {"address": CHANNEL_REDIS_HOST, "socket_timeout": None},
+                {
+                    "address": CHANNEL_REDIS_HOST,
+                    # Redis>=8 changed the default timeout of read
+                    # operations to 5 seconds, which breaks django-channels,
+                    # hence we need to explicitly remove the timeout.
+                    "socket_timeout": None,
+                },
             ],
         },
     },

--- a/images/common/openwisp/settings.py
+++ b/images/common/openwisp/settings.py
@@ -229,7 +229,11 @@ OPENWISP_MONITORING_DEFAULT_RETENTION_POLICY = os.environ[
 CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {"hosts": [CHANNEL_REDIS_HOST]},
+        "CONFIG": {
+            "hosts": [
+                {"address": CHANNEL_REDIS_HOST, "socket_timeout": None},
+            ],
+        },
     },
 }
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -65,19 +65,6 @@ class Test0Preconditions(BaseTestUtils, unittest.TestCase):
 
 
 class Test1Dashboard(BaseTestUtils, unittest.TestCase):
-    def test_dashboard_channels_redis_socket_timeout(self):
-        channel_redis_url = "redis://redis:6379/1"
-        output, _ = self._execute_django_shell_command(
-            "from django.conf import settings; import json; print(json.dumps("
-            "settings.CHANNEL_LAYERS['default']['CONFIG']['hosts'][0]))",
-            environment={"CHANNEL_REDIS_URL": channel_redis_url},
-        )
-        self.assertEqual(
-            json.loads(output.strip().splitlines()[-1]),
-            {"address": channel_redis_url, "socket_timeout": None},
-            "Channels Redis host must have an unlimited socket timeout.",
-        )
-
     def test_dashboard_uses_same_origin_api_urls(self):
         """Ensure dashboard browser requests use module default relative URLs."""
         output, _ = self._execute_django_shell_command(
@@ -147,6 +134,19 @@ class Test1Dashboard(BaseTestUtils, unittest.TestCase):
             output.strip().splitlines()[-1],
             "False",
             "Dashboard must not serve disabled RADIUS API URLs.",
+        )
+
+    def test_dashboard_channels_redis_socket_timeout(self):
+        channel_redis_url = "redis://redis:6379/1"
+        output, _ = self._execute_django_shell_command(
+            "from django.conf import settings; import json; print(json.dumps("
+            "settings.CHANNEL_LAYERS['default']['CONFIG']['hosts'][0]))",
+            environment={"CHANNEL_REDIS_URL": channel_redis_url},
+        )
+        self.assertEqual(
+            json.loads(output.strip().splitlines()[-1]),
+            {"address": channel_redis_url, "socket_timeout": None},
+            "Channels Redis host must have an unlimited socket timeout.",
         )
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import tempfile
@@ -64,6 +65,19 @@ class Test0Preconditions(BaseTestUtils, unittest.TestCase):
 
 
 class Test1Dashboard(BaseTestUtils, unittest.TestCase):
+    def test_dashboard_channels_redis_socket_timeout(self):
+        channel_redis_url = "redis://redis:6379/1"
+        output, _ = self._execute_django_shell_command(
+            "from django.conf import settings; import json; print(json.dumps("
+            "settings.CHANNEL_LAYERS['default']['CONFIG']['hosts'][0]))",
+            environment={"CHANNEL_REDIS_URL": channel_redis_url},
+        )
+        self.assertEqual(
+            json.loads(output.strip().splitlines()[-1]),
+            {"address": channel_redis_url, "socket_timeout": None},
+            "Channels Redis host must have an unlimited socket timeout.",
+        )
+
     def test_dashboard_uses_same_origin_api_urls(self):
         """Ensure dashboard browser requests use module default relative URLs."""
         output, _ = self._execute_django_shell_command(


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Configures the Channels Redis host with `socket_timeout: None` to preserve blocking channel-layer reads with redis-py 8.

## Screenshot

N/A