### PR TITLE
[ci] Improved compose logs shown on failures to ease debugging

### DIFF
--- a/.github/scripts/docker-compose-failure-diagnostics.sh
+++ b/.github/scripts/docker-compose-failure-diagnostics.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -u
+
+readonly test_logs_file=/tmp/docker-openwisp-tests.log
+
+echo "Docker compose service status:"
+docker compose ps --all || true
+
+mapfile -t container_ids < <(docker compose ps --all --quiet || true)
+if ((${#container_ids[@]})); then
+    echo "Docker container details:"
+    docker inspect \
+        --format '{{.Name}} state={{.State.Status}} exit={{.State.ExitCode}}'\
+        ' oom={{.State.OOMKilled}} error={{.State.Error}}'\
+        ' restarts={{.RestartCount}}' \
+        "${container_ids[@]}" || true
+fi
+
+printf '\nLast 500 lines from dashboard:\n'
+docker compose logs --tail=500 --no-log-prefix dashboard || true
+
+if [ -f "$test_logs_file" ]; then
+	printf '\nLast 500 lines from Docker compose test commands:\n'
+	tail -n 500 "$test_logs_file" || true
+fi
+
+found_non_running_service=false
+while read -r service state; do
+	if [ "$state" = "running" ] || [ "$service" = "dashboard" ]; then
+		continue
+	fi
+	found_non_running_service=true
+	printf '\nLast 500 lines from %s (%s):\n' "$service" "$state"
+	docker compose logs --tail=500 --no-log-prefix "$service" || true
+done < <(docker compose ps --all --format '{{.Service}} {{.State}}' || true)
+
+if [ "$found_non_running_service" = false ]; then
+	echo "No non-running containers found."
+fi

--- a/.github/scripts/docker-compose-failure-diagnostics.sh
+++ b/.github/scripts/docker-compose-failure-diagnostics.sh
@@ -4,18 +4,36 @@ set -u
 
 readonly test_logs_file=/tmp/docker-openwisp-tests.log
 
+wait_for_dashboard_restart() {
+	local container_id current_restarts restarts
+
+	container_id=$(docker compose ps --quiet dashboard) || return
+	[ -n "$container_id" ] || return
+	restarts=$(docker inspect --format '{{.RestartCount}}' "$container_id") || return
+
+	for _ in {1..60}; do
+		sleep 1
+		current_restarts=$(docker inspect --format '{{.RestartCount}}' "$container_id") || return
+		if [ "$current_restarts" -gt "$restarts" ]; then
+			return
+		fi
+	done
+}
+
 echo "Docker compose service status:"
 docker compose ps --all || true
 
 mapfile -t container_ids < <(docker compose ps --all --quiet || true)
 if ((${#container_ids[@]})); then
-    echo "Docker container details:"
-    docker inspect \
-        --format '{{.Name}} state={{.State.Status}} exit={{.State.ExitCode}}'\
-        ' oom={{.State.OOMKilled}} error={{.State.Error}}'\
-        ' restarts={{.RestartCount}}' \
-        "${container_ids[@]}" || true
+	echo "Docker container details:"
+	docker inspect \
+		--format "{{.Name}} state={{.State.Status}} exit={{.State.ExitCode}} \
+oom={{.State.OOMKilled}} error={{.State.Error}} \
+restarts={{.RestartCount}}" \
+		"${container_ids[@]}" || true
 fi
+
+wait_for_dashboard_restart
 
 printf '\nLast 500 lines from dashboard:\n'
 docker compose logs --tail=500 --no-log-prefix dashboard || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
 
       - name: Docker compose failure diagnostics
         if: ${{ failure() && steps.enable_development_profile.conclusion == 'success' }}
-        run: bash .github/scripts/docker-compose-failure-diagnostics.sh
+        run: |
+          bash .github/scripts/docker-compose-failure-diagnostics.sh
+          # Intentionally fail so CI highlights this step and directs maintainers
+          # and developers to the logs needed for debugging.
+          exit 1
         working-directory: /opt/openwisp/docker-openwisp
 
       - name: Stop containers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,32 @@ jobs:
           # execute the test from this directory.
           # The containers are already running, so use the target that only
           # executes Python tests without restarting or stopping the stack.
-          command: cd /opt/openwisp/docker-openwisp && make develop-pythontests
+          command: |
+            cd /opt/openwisp/docker-openwisp && make develop-pythontests || {
+              echo "Look at the \"Docker compose failure logs\" step for details."
+              false
+            }
         env:
           SELENIUM_HEADLESS: 1
 
-      - name: Print docker logs
-        if: ${{ failure() }}
-        run: docker compose logs
+      # Prints the relevant docker compose logs on failure
+      - name: Docker compose failure logs
+        if: ${{ failure() && steps.enable_development_profile.conclusion == 'success' }}
+        run: |
+          cd /opt/openwisp/docker-openwisp
+          found_non_running_service=false
+          while read -r service state; do
+            if [ "$state" = "running" ]; then
+              continue
+            fi
+            found_non_running_service=true
+            printf '\nLast 500 lines from %s (%s):\n' "$service" "$state"
+            docker compose logs --tail=500 --no-log-prefix "$service" || true
+          done < <(docker compose ps --all --format '{{.Service}} {{.State}}')
+          if [ "$found_non_running_service" = false ]; then
+            echo "No non-running containers found."
+          fi
+          exit 1
 
       - name: Stop containers
         # Run teardown exactly once after the retry loop, regardless of the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: CI Build
@@ -104,7 +107,7 @@ jobs:
           SELENIUM_HEADLESS: 1
 
       - name: Docker compose failure diagnostics
-        if: ${{ failure() && steps.enable_development_profile.conclusion == 'success' }}
+        if: ${{ failure() && steps.auto_install_upgrade.conclusion == 'success' }}
         run: |
           bash .github/scripts/docker-compose-failure-diagnostics.sh
           # Intentionally fail so CI highlights this step and directs maintainers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,32 +99,14 @@ jobs:
           # execute the test from this directory.
           # The containers are already running, so use the target that only
           # executes Python tests without restarting or stopping the stack.
-          command: |
-            cd /opt/openwisp/docker-openwisp && make develop-pythontests || {
-              echo "Look at the \"Docker compose failure logs\" step for details."
-              false
-            }
+          command: cd /opt/openwisp/docker-openwisp && make develop-pythontests
         env:
           SELENIUM_HEADLESS: 1
 
-      # Prints the relevant docker compose logs on failure
-      - name: Docker compose failure logs
+      - name: Docker compose failure diagnostics
         if: ${{ failure() && steps.enable_development_profile.conclusion == 'success' }}
-        run: |
-          cd /opt/openwisp/docker-openwisp
-          found_non_running_service=false
-          while read -r service state; do
-            if [ "$state" = "running" ]; then
-              continue
-            fi
-            found_non_running_service=true
-            printf '\nLast 500 lines from %s (%s):\n' "$service" "$state"
-            docker compose logs --tail=500 --no-log-prefix "$service" || true
-          done < <(docker compose ps --all --format '{{.Service}} {{.State}}')
-          if [ "$found_non_running_service" = false ]; then
-            echo "No non-running containers found."
-          fi
-          exit 1
+        run: bash .github/scripts/docker-compose-failure-diagnostics.sh
+        working-directory: /opt/openwisp/docker-openwisp
 
       - name: Stop containers
         # Run teardown exactly once after the retry loop, regardless of the

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -30,8 +30,9 @@ ENV PATH="${PATH}:/home/openwisp/.local/bin"
 
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade pip setuptools wheel
-# Temporarily install the OpenWISP modules from their 1.3 development
-# branch until the 1.3 line is released; switch back to ~=1.3.0 then.
+# Temporarily install the OpenWISP modules from their 1.3 development line
+# until the 1.3 line is released. Monitoring and Topology use pinned commits
+# to reproduce CI startup failures, while Firmware and Radius use 1.3 branches.
 ARG OPENWISP_MONITORING_SOURCE="https://github.com/openwisp/openwisp-monitoring/tarball/e97ee4a8ae39764ac0e3fc63644138f31d0489cd"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_MONITORING_SOURCE}

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -30,16 +30,13 @@ ENV PATH="${PATH}:/home/openwisp/.local/bin"
 
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade pip setuptools wheel
-# Temporarily install the OpenWISP modules from their 1.3 development line
-# until the 1.3 line is released. Monitoring and Topology use pinned commits
-# to reproduce CI startup failures, while Firmware and Radius use 1.3 packages.
-ARG OPENWISP_MONITORING_SOURCE="https://github.com/openwisp/openwisp-monitoring/tarball/e97ee4a8ae39764ac0e3fc63644138f31d0489cd"
+ARG OPENWISP_MONITORING_SOURCE="openwisp-monitoring~=1.3.0"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_MONITORING_SOURCE}
 ARG OPENWISP_FIRMWARE_SOURCE="openwisp-firmware-upgrader~=1.3.0"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_FIRMWARE_SOURCE}
-ARG OPENWISP_TOPOLOGY_SOURCE="https://github.com/openwisp/openwisp-network-topology/tarball/20697f45784bc548aadfc9500782c4940429e82b"
+ARG OPENWISP_TOPOLOGY_SOURCE="openwisp-network-topology~=1.3.0"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_TOPOLOGY_SOURCE}
 ARG OPENWISP_RADIUS_SOURCE="openwisp-radius~=1.3.0"

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -30,13 +30,15 @@ ENV PATH="${PATH}:/home/openwisp/.local/bin"
 
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade pip setuptools wheel
-ARG OPENWISP_MONITORING_SOURCE="openwisp-monitoring~=1.3.0"
+# Temporarily install the OpenWISP modules from their 1.3 development
+# branch until the 1.3 line is released; switch back to ~=1.3.0 then.
+ARG OPENWISP_MONITORING_SOURCE="https://github.com/openwisp/openwisp-monitoring/tarball/e97ee4a8ae39764ac0e3fc63644138f31d0489cd"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_MONITORING_SOURCE}
 ARG OPENWISP_FIRMWARE_SOURCE="openwisp-firmware-upgrader~=1.3.0"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_FIRMWARE_SOURCE}
-ARG OPENWISP_TOPOLOGY_SOURCE="openwisp-network-topology~=1.3.0"
+ARG OPENWISP_TOPOLOGY_SOURCE="https://github.com/openwisp/openwisp-network-topology/tarball/20697f45784bc548aadfc9500782c4940429e82b"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_TOPOLOGY_SOURCE}
 ARG OPENWISP_RADIUS_SOURCE="openwisp-radius~=1.3.0"

--- a/images/openwisp_base/Dockerfile
+++ b/images/openwisp_base/Dockerfile
@@ -32,7 +32,7 @@ ENV PATH="${PATH}:/home/openwisp/.local/bin"
 RUN pip install --no-cache-dir --user --upgrade pip setuptools wheel
 # Temporarily install the OpenWISP modules from their 1.3 development line
 # until the 1.3 line is released. Monitoring and Topology use pinned commits
-# to reproduce CI startup failures, while Firmware and Radius use 1.3 branches.
+# to reproduce CI startup failures, while Firmware and Radius use 1.3 packages.
 ARG OPENWISP_MONITORING_SOURCE="https://github.com/openwisp/openwisp-monitoring/tarball/e97ee4a8ae39764ac0e3fc63644138f31d0489cd"
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir --user --upgrade ${OPENWISP_MONITORING_SOURCE}

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -10,6 +10,7 @@ echo ''
 echo 'Shell scripts QA checks ...'
 # check shell scripts formatting
 shfmt --apply-ignore -d .
+shellcheck .github/scripts/*.sh
 
 echo ''
 echo 'Dockerfile QA checks...'

--- a/tests/config.json
+++ b/tests/config.json
@@ -5,7 +5,7 @@
   "api_url": "https://api.openwisp.org",
   "load_init_data": true,
   "logs": false,
-  "logs_file": "/tmp/odocker.log",
+  "logs_file": "/tmp/docker-openwisp-tests.log",
   "username": "admin",
   "password": "admin",
   "services_max_retries": 25,


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

When docker containers have troubles to start, the current CI pipeline makes debugging almost impossible.

This patch aims to show the logs of docker containers which cannot start due to failures and bugs.